### PR TITLE
feat: Add API Endpoint for Fetching Scorecard Score 

### DIFF
--- a/webapp/backend/.env.example
+++ b/webapp/backend/.env.example
@@ -12,3 +12,5 @@ API_PORT=8000
 LOG_LEVEL=INFO 
 
 ALLIUM_API_KEY="allium_api_key_here"
+
+GITHUB_TOKEN="github_token_here"

--- a/webapp/backend/Dockerfile
+++ b/webapp/backend/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /backend
 RUN apt-get update && apt-get install -y \
     gcc \
     python3-dev \
+    docker.io \
     && rm -rf /var/lib/apt/lists/*
+
     
 # Copy files
 COPY requirements.txt .

--- a/webapp/backend/core/config.py
+++ b/webapp/backend/core/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     # Allium API Key
     allium_api_key: str
 
+    # Github Token
+    github_token: str
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
@@ -31,6 +34,7 @@ class Settings(BaseSettings):
             "api_port": "API_PORT",
             "log_level": "LOG_LEVEL",
             "allium_api_key": "ALLIUM_API_KEY",
+            "github_token": "GITHUB_TOKEN",
         }
 
 

--- a/webapp/backend/schemas/info.py
+++ b/webapp/backend/schemas/info.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Literal, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl
 
 
 class LatestBlockResponse(BaseModel):
@@ -32,3 +32,16 @@ class VerificationInfoResponse(BaseModel):
         ..., description="Verification status"
     )
     verifiedAt: str = Field(None, description="Verification date")
+
+class ScorecardRequest(BaseModel):
+    """Request model for scorecard data."""
+    org: str = Field(..., min_length=1, max_length=50, description="GitHub organization name")
+    repo: str = Field(..., min_length=1, max_length=100, description="GitHub repository name")
+
+
+class ScorecardResponse(BaseModel):
+    repo_info: str
+    source: str
+    score: float
+    date: str
+    checks: List[dict]


### PR DESCRIPTION
This PR adds a new API endpoint to fetch the [OpenSSF Scorecard](https://github.com/ossf/scorecard) for a given GitHub repository.

🔍 How It Works
- Primary source:
Attempts to retrieve a precomputed score from the public Scorecard API.

- Fallback mechanism:
If the repository is not included in the public dataset, the backend will run scorecard locally to compute the score.(🛠️ Requires a valid GitHub token for accessing repository data.)

🆕 New API Endpoint
`POST /info/reposcore`

Request Body:
```
{
  "org": "string",
  "repo": "string"
}
```

return:
```
{
  "repo_info": "string",
  "source": "string",
  "score": 0,
  "date": "string",
  "checks": [
    {
      "additionalProp1": {}
    }
  ]
}
```

close #81 