### PR TITLE
Feat: add metadata for risk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ __pycache__/
 # C extensions
 *.so
 
+node_modules/
+
 # Distribution / packaging
 .Python
 build/

--- a/webapp/backend/routers/analysis.py
+++ b/webapp/backend/routers/analysis.py
@@ -103,4 +103,5 @@ async def get_contract_risk(address: str, session: Session = Depends(get_session
         address=request.address,
         risk_score=risk_data["risk_score"],
         risk_factors=risk_data["risk_factors"],
+        attestation=risk_data["attestation"],
     )

--- a/webapp/backend/schemas/analysis.py
+++ b/webapp/backend/schemas/analysis.py
@@ -38,4 +38,8 @@ class ContractRiskResponse(BaseModel):
     risk_factors: Dict[str, Any] = Field(
         ..., description="Detailed risk factors"
     )
+    attestation: Dict[str, Any] = Field(
+        ...,
+        description="Attestation data",
+    )   
 

--- a/webapp/backend/services/analysis_service.py
+++ b/webapp/backend/services/analysis_service.py
@@ -205,6 +205,8 @@ async def calculate_contract_risk(address: str, session: Session) -> Dict[str, A
         "onchain_attestation_url": f"https://onchain.mab.xyz/attestation/{random_signature}"
     }
     
+
+    logger.info(f"Risk score: {risk_score}, Risk factors: {risk_factors}, Attestation: {attestation}")
     return {
         "risk_score": risk_score, 
         "risk_factors": risk_factors,

--- a/webapp/backend/services/analysis_service.py
+++ b/webapp/backend/services/analysis_service.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict, Optional, List
 
+import secrets
+from datetime import datetime
+
 from loguru import logger
 from scsc.supply_chain import SupplyChain
 
@@ -189,4 +192,21 @@ async def calculate_contract_risk(address: str, session: Session) -> Dict[str, A
 
     score = 0.1 * verification_score + 0.05 * proxy_score + 0.05 * permissions_score + 0.3 * scorecard_score + 0.5 * audits_score
     risk_score = round((1-score) * 100)
-    return {"risk_score": risk_score, "risk_factors": risk_factors}
+
+        # Generate MAB attestation metadata
+    current_timestamp = datetime.utcnow().isoformat() + "Z"
+    random_signature = secrets.token_hex(32)  # 64-character hex string
+    
+    # Create attestation metadata
+    attestation = {
+        "by": "mab.xyz",
+        "date": current_timestamp,
+        "signature": random_signature,
+        "onchain_attestation_url": f"https://onchain.mab.xyz/attestation/{random_signature}"
+    }
+    
+    return {
+        "risk_score": risk_score, 
+        "risk_factors": risk_factors,
+        "attestation": attestation
+    }


### PR DESCRIPTION
Add attestation for risk score

```
attestation = {
        "by": "mab.xyz",
        "date": current_timestamp,
        "signature": random_signature,
        "onchain_attestation_url": f"https://onchain.mab.xyz/attestation/{random_signature}"
    }
```

closes #103 