### PR TITLE
Refactor: reposcore endpoint for given address

### DIFF
--- a/webapp/backend/routers/info.py
+++ b/webapp/backend/routers/info.py
@@ -14,7 +14,6 @@ from schemas.info import (
     PermissionsInfoResponse,
 )
 from schemas.response import ErrorResponse
-from schemas.info import ScorecardRequest
 from services.info_service import (
     get_latest_block_number,
     get_deployment_data,
@@ -123,8 +122,8 @@ async def get_contract_info(
         verifiedAt=data["verifiedAt"],
     )
 
-@router.post(
-    "/reposcore",
+@router.get(
+    "/reposcore/{address}",
     status_code=status.HTTP_200_OK,
     response_model=ScorecardResponse,
     responses={
@@ -146,12 +145,14 @@ async def get_contract_info(
 )
 @cache(expire=settings.cache_ttl)
 async def get_scorecard_info(
-    request: ScorecardRequest,
+    address: str,
+    session: Session = Depends(get_session),
     ):
     """
-    Get scorecard data for a given repository.
+    Get scorecard data for a given smart contract address.
     """
-    scorecard_data = get_scorecard_data(request.org, request.repo)
+
+    scorecard_data = await get_scorecard_data(session, address)
 
     source = "public_api" if scorecard_data["source"] == "api" else "scorecard_docker"
     org_repo = scorecard_data["repo"]

--- a/webapp/backend/schemas/info.py
+++ b/webapp/backend/schemas/info.py
@@ -33,11 +33,6 @@ class VerificationInfoResponse(BaseModel):
     )
     verifiedAt: str = Field(None, description="Verification date")
 
-class ScorecardRequest(BaseModel):
-    """Request model for scorecard data."""
-    org: str = Field(..., min_length=1, max_length=50, description="GitHub organization name")
-    repo: str = Field(..., min_length=1, max_length=100, description="GitHub repository name")
-
 
 class ScorecardResponse(BaseModel):
     repo_info: str

--- a/webapp/backend/services/analysis_service.py
+++ b/webapp/backend/services/analysis_service.py
@@ -165,11 +165,7 @@ async def calculate_contract_risk(address: str, session: Session) -> Dict[str, A
 
     try:
         logger.info("Fetching scorecard data.")
-        repo_data = await contract_service.get_contract_repository(address)
-        url = repo_data["repository"].url
-        url_elms = url.split("/")
-        org, repo = url_elms[-2], url_elms[-1]
-        scorecard_data = get_scorecard_data(org, repo)
+        scorecard_data = await get_scorecard_data(session, address)
         scorecard_score = scorecard_data["raw"]["score"]
         scorecard_score = scorecard_score / 10
     except Exception as e:


### PR DESCRIPTION
This PR changes the `/info/reposcore` endpoint, it receives a contract address now instead of repository and organization data.

closes #117 