### PR TITLE
CI: pypi publish workflow

### DIFF
--- a/.github/workflows/crystal_clear_publish.yml
+++ b/.github/workflows/crystal_clear_publish.yml
@@ -1,0 +1,30 @@
+name: Publish Crystal-Clear Package on PYPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'   # e.g., v0.1.0, v1.2.3
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webapp/backend/crystal-clear
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install Poetry
+        run: python -m pip install poetry
+
+      - name: Configure Poetry for PyPI
+        run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish package
+        run: poetry publish --build --no-interaction

--- a/webapp/backend/crystal-clear/pyproject.toml
+++ b/webapp/backend/crystal-clear/pyproject.toml
@@ -7,6 +7,10 @@ authors = [
     {name = "Raphina Liu", email = "raphinaliu@gmail.com"},
     {name = "Martin Monperrus", email= "martin@monperrus.com"}
 ]
+packages = [
+    { include = "crystal_clear" },
+    { include = "cli" }
+]
 license = "MIT"
 readme = "README.md"
 requires-python = ">3.12.0,<4"


### PR DESCRIPTION
This pull request introduces automation for publishing the `crystal-clear` Python package to PyPI and updates the package configuration to ensure both the main package and its CLI are included in releases.

**CI/CD Automation:**

* Added a new GitHub Actions workflow (`.github/workflows/crystal_clear_publish.yml`) to automatically publish the `crystal-clear` package to PyPI whenever a new version tag is pushed. This workflow sets up Python, installs Poetry, configures the PyPI token, and publishes the package.

**Packaging Improvements:**

* Updated `pyproject.toml` to explicitly include both the `crystal_clear` and `cli` packages in the distribution, ensuring they are part of published releases.