### PR TITLE
Fix: openapi export with missing env

### DIFF
--- a/.github/workflows/api_export_openapi.yml
+++ b/.github/workflows/api_export_openapi.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction
+
+    - name: Copy .env.example to .env
+      run: cp .env.example .env
     
     - name: Generate OpenAPI spec
       run: |


### PR DESCRIPTION
Generate .env in the workflow to avoid pydantic errors.