### PR TITLE
Change interaction logic to include transitive interactions

### DIFF
--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -113,11 +113,19 @@ def _evaluate_interaction_scan_risk(
     if root_norm:
         from_candidates.add(root_norm)
 
+    # Also fetch the "direct" counterpart so the direct⊂transitive implication
+    # can fire even when only the transitive type was requested.
+    query_types = set(checked_interaction_types)
+    if "contract_transitive" in query_types:
+        query_types.add("contract_direct")
+    if "sender_transitive" in query_types:
+        query_types.add("sender_direct")
+
     rows = session.exec(
         select(InteractionScanState).where(
             InteractionScanState.from_address.in_(list(from_candidates)),
             InteractionScanState.to_address.in_(normalized_targets),
-            InteractionScanState.interaction_type.in_(checked_interaction_types),
+            InteractionScanState.interaction_type.in_(list(query_types)),
         )
     ).all()
     row_index = {
@@ -184,8 +192,43 @@ def _evaluate_interaction_scan_risk(
 
             first_time_map[target][interaction_type] = first_time_val
             state_map[target][interaction_type] = state_val
-            if not first_time_val:
+
+        # Implication: direct interaction ⊂ transitive interaction.
+        # If contract_direct is not first-time, contract_transitive cannot be either.
+        # This works even when contract_direct was not in checked_interaction_types
+        # because we fetched the direct rows in the query above.
+        def _direct_is_not_first_time(from_addr: str | None, target: str, direct_type: str) -> bool:
+            """Check if the direct counterpart has a known prior interaction."""
+            if not from_addr:
+                return False
+            # Already evaluated in the loop above
+            if direct_type in first_time_map.get(target, {}):
+                return not first_time_map[target][direct_type]
+            # Not in checked types, but may exist in DB via the expanded query
+            row = row_index.get((from_addr, target, direct_type))
+            return row is not None and not row.first_time_interact
+
+        if (
+            first_time_map[target].get("contract_transitive", False)
+            and _direct_is_not_first_time(root_norm, target, "contract_direct")
+        ):
+            first_time_map[target]["contract_transitive"] = False
+            if state_map[target].get("contract_transitive") == "MISSING":
+                state_map[target]["contract_transitive"] = "FOUND"
+
+        if (
+            first_time_map[target].get("sender_transitive", False)
+            and _direct_is_not_first_time(sender_norm, target, "sender_direct")
+        ):
+            first_time_map[target]["sender_transitive"] = False
+            if state_map[target].get("sender_transitive") == "MISSING":
+                state_map[target]["sender_transitive"] = "FOUND"
+
+        for interaction_type in checked_interaction_types:
+            first_time_val = first_time_map[target].get(interaction_type)
+            if first_time_val is None or not first_time_val:
                 continue
+            state_val = state_map[target].get(interaction_type, "MISSING")
             # MISSING history: we lack data — flag as potential, not confirmed.
             if state_val == "MISSING":
                 if (

--- a/webapp/backend/tests/routers/test_analysis_interaction_helpers_extra.py
+++ b/webapp/backend/tests/routers/test_analysis_interaction_helpers_extra.py
@@ -308,3 +308,159 @@ def test_evaluate_interaction_scan_risk_contract_direct_first_time_without_skip(
     assert state_map[target]["contract_direct"] == "FOUND"
     assert contract_dangerous == ["contract_direct"]
     assert contract_missing == []
+
+
+# If contract_direct is not first-time, contract_transitive must also not be
+# first-time (direct ⊂ transitive). Even when the transitive row is MISSING
+# in the DB, the implication overrides it to FOUND/not-first-time.
+def test_evaluate_contract_direct_not_first_time_implies_transitive_not_first_time():
+    sender = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    root = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    target = "0xcccccccccccccccccccccccccccccccccccccccc"
+    # contract_direct exists and is not first-time
+    row_direct = SimpleNamespace(
+        from_address=root,
+        to_address=target,
+        interaction_type="contract_direct",
+        first_time_interact=False,
+    )
+    # No contract_transitive row in DB (MISSING)
+    session = _Session([row_direct])
+
+    (
+        first_map,
+        state_map,
+        contract_dangerous,
+        sender_dangerous,
+        contract_missing,
+        sender_missing,
+    ) = analysis._evaluate_interaction_scan_risk(
+        session=session,
+        sender_address=sender,
+        root_contract=root,
+        touched_addresses=[target],
+        checked_interaction_types=["contract_direct", "contract_transitive"],
+    )
+
+    assert first_map[target]["contract_direct"] is False
+    assert state_map[target]["contract_direct"] == "FOUND"
+    # Transitive must be inferred as not first-time from direct
+    assert first_map[target]["contract_transitive"] is False
+    assert state_map[target]["contract_transitive"] == "FOUND"
+    assert contract_dangerous == []
+    assert contract_missing == []
+
+
+# Same implication for sender: sender_direct not first-time implies
+# sender_transitive not first-time.
+def test_evaluate_sender_direct_not_first_time_implies_transitive_not_first_time():
+    sender = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    root = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    target = "0xcccccccccccccccccccccccccccccccccccccccc"
+    row_direct = SimpleNamespace(
+        from_address=sender,
+        to_address=target,
+        interaction_type="sender_direct",
+        first_time_interact=False,
+    )
+    session = _Session([row_direct])
+
+    (
+        first_map,
+        state_map,
+        contract_dangerous,
+        sender_dangerous,
+        contract_missing,
+        sender_missing,
+    ) = analysis._evaluate_interaction_scan_risk(
+        session=session,
+        sender_address=sender,
+        root_contract=root,
+        touched_addresses=[target],
+        checked_interaction_types=["sender_direct", "sender_transitive"],
+    )
+
+    assert first_map[target]["sender_direct"] is False
+    assert first_map[target]["sender_transitive"] is False
+    assert state_map[target]["sender_transitive"] == "FOUND"
+    assert sender_dangerous == []
+    assert sender_missing == []
+
+
+# When contract_direct IS first-time, the implication must NOT fire —
+# contract_transitive should retain its own DB state.
+def test_evaluate_contract_direct_first_time_does_not_override_transitive():
+    sender = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    root = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    target = "0xcccccccccccccccccccccccccccccccccccccccc"
+    row_direct = SimpleNamespace(
+        from_address=root,
+        to_address=target,
+        interaction_type="contract_direct",
+        first_time_interact=True,
+    )
+    row_transitive = SimpleNamespace(
+        from_address=root,
+        to_address=target,
+        interaction_type="contract_transitive",
+        first_time_interact=True,
+    )
+    session = _Session([row_direct, row_transitive])
+
+    (
+        first_map,
+        state_map,
+        contract_dangerous,
+        _sender_dangerous,
+        contract_missing,
+        _sender_missing,
+    ) = analysis._evaluate_interaction_scan_risk(
+        session=session,
+        sender_address=sender,
+        root_contract=root,
+        touched_addresses=[target],
+        checked_interaction_types=["contract_direct", "contract_transitive"],
+    )
+
+    assert first_map[target]["contract_direct"] is True
+    assert first_map[target]["contract_transitive"] is True
+    assert contract_dangerous == ["contract_direct", "contract_transitive"]
+
+
+# When the endpoint only checks contract_transitive (not contract_direct),
+# the implication should still fire by looking up contract_direct from the DB.
+def test_evaluate_transitive_only_checked_but_direct_exists_in_db():
+    sender = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    root = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    target = "0xcccccccccccccccccccccccccccccccccccccccc"
+    # contract_direct exists in DB as not first-time, but is NOT in checked types
+    row_direct = SimpleNamespace(
+        from_address=root,
+        to_address=target,
+        interaction_type="contract_direct",
+        first_time_interact=False,
+    )
+    # No contract_transitive row in DB
+    session = _Session([row_direct])
+
+    (
+        first_map,
+        state_map,
+        contract_dangerous,
+        sender_dangerous,
+        contract_missing,
+        sender_missing,
+    ) = analysis._evaluate_interaction_scan_risk(
+        session=session,
+        sender_address=sender,
+        root_contract=root,
+        touched_addresses=[target],
+        # Only checking transitive, not direct
+        checked_interaction_types=["contract_transitive"],
+    )
+
+    # Transitive was MISSING in DB but inferred from direct
+    assert first_map[target]["contract_transitive"] is False
+    assert state_map[target]["contract_transitive"] == "FOUND"
+    assert contract_dangerous == []
+    assert contract_missing == []


### PR DESCRIPTION
This pull request updates the interaction scan risk evaluation logic to enforce that a "direct" interaction always implies the corresponding "transitive" interaction is also not first-time, even if only the transitive type was requested. The changes ensure correct inference and add comprehensive test coverage for these cases.

**Interaction scan logic improvements:**

* The query in `_evaluate_interaction_scan_risk` now always fetches both "direct" and "transitive" interaction types when a transitive type is checked, ensuring the direct⊂transitive implication can be applied even if only the transitive type was requested.
* Added logic to enforce that if a "direct" interaction is not first-time, the corresponding "transitive" interaction is also marked as not first-time, updating state as needed. This implication works even when the transitive row is missing in the database.

