### PR TITLE
feat: add ok_reason='to EOA' for plain ETH transfers

### DIFF
--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -501,15 +501,23 @@ async def simulate_transaction(
     if _has_unverified_dangerous(items):
         status = "DANGEROUS"
         danger_reason = "UNVERIFIED"
+        ok_reason = None
     elif contract_dangerous_types:
         status = "DANGEROUS"
         danger_reason = "FIRST_TIME_INTERACTION"
+        ok_reason = None
     elif contract_missing_types:
         status = "POTENTIAL_DANGEROUS"
         danger_reason = "MISSING_HISTORY"
+        ok_reason = None
     else:
         status = "OK"
         danger_reason = None
+        ok_reason = (
+            "to EOA"
+            if (call_object.get("to") and not touched_addresses)
+            else None
+        )
     interaction_status = _build_interaction_status(
         checked_interaction_types,
         contract_dangerous_types + sender_dangerous_types,
@@ -522,6 +530,7 @@ async def simulate_transaction(
         details=items,
         dangerous_interaction_types=contract_dangerous_types,
         danger_reason=danger_reason,
+        ok_reason=ok_reason,
     )
 
 
@@ -893,15 +902,23 @@ async def get_tx_risk_from_raw(
     if _has_unverified_dangerous(items):
         status_val = "DANGEROUS"
         danger_reason = "UNVERIFIED"
+        ok_reason = None
     elif contract_dangerous_types:
         status_val = "DANGEROUS"
         danger_reason = "FIRST_TIME_INTERACTION"
+        ok_reason = None
     elif contract_missing_types:
         status_val = "POTENTIAL_DANGEROUS"
         danger_reason = "MISSING_HISTORY"
+        ok_reason = None
     else:
         status_val = "OK"
         danger_reason = None
+        ok_reason = (
+            "to EOA"
+            if (call_object.get("to") and not touched_addresses)
+            else None
+        )
     interaction_status = _build_interaction_status(
         checked_interaction_types,
         contract_dangerous_types + sender_dangerous_types,
@@ -913,5 +930,6 @@ async def get_tx_risk_from_raw(
         details=items,
         dangerous_interaction_types=contract_dangerous_types,
         danger_reason=danger_reason,
+        ok_reason=ok_reason,
     )
     return resp

--- a/webapp/backend/src/api/schemas/analysis.py
+++ b/webapp/backend/src/api/schemas/analysis.py
@@ -385,6 +385,13 @@ class SimulationResponse(BaseModel):
             "available; UNVERIFIED = contract source code is not verified on-chain."
         ),
     )
+    ok_reason: Optional[Literal["to EOA"]] = Field(
+        None,
+        description=(
+            "Reason the verdict is OK when the transaction touches no contracts. "
+            "to EOA = the destination address has no bytecode (plain ETH transfer)."
+        ),
+    )
 
 
 class RawTxRiskRequest(BaseModel):

--- a/webapp/backend/tests/routers/test_analysis_router_tx_raw_extra.py
+++ b/webapp/backend/tests/routers/test_analysis_router_tx_raw_extra.py
@@ -810,6 +810,7 @@ async def test_simulate_transaction_eoa_target_is_ok(monkeypatch):
 
     assert response.status == "OK"
     assert response.danger_reason is None
+    assert response.ok_reason == "to EOA"
     assert response.details == []
 
 
@@ -846,6 +847,7 @@ async def test_tx_risk_raw_eoa_target_is_ok(monkeypatch):
 
     assert response.status == "OK"
     assert response.danger_reason is None
+    assert response.ok_reason == "to EOA"
     assert response.details == []
 
 


### PR DESCRIPTION
## Summary

- Adds `ok_reason: Optional[Literal["to EOA"]]` field to `SimulationResponse`
- Sets `ok_reason = "to EOA"` in `simulate_transaction` and `get_tx_risk_from_raw` routes when the transaction targets an EOA (destination address has no bytecode → empty `touched_addresses`)
- Extends existing EOA regression tests to assert `response.ok_reason == "to EOA"`

## Test plan

- [ ] `test_simulate_transaction_eoa_target_is_ok` now asserts `ok_reason == "to EOA"`
- [ ] `test_tx_risk_raw_eoa_target_is_ok` now asserts `ok_reason == "to EOA"`
- [ ] Full test suite: 224 passed

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)