### PR TITLE
fix: preserve supply-chain breadth when sampling trace transactions

### DIFF
--- a/webapp/backend/crystal-clear/crystal_clear/traces/trace_collector.py
+++ b/webapp/backend/crystal-clear/crystal_clear/traces/trace_collector.py
@@ -257,30 +257,50 @@ class TraceCollector:
             "toBlock": to_block,
             "fromAddress": [contract_address],
         }
-        try:
-            res = self.w3.tracing.trace_filter(filter_params)
-        except Exception as e:
-            self.logger.error(f"Error filtering transactions: {e}")
-            return set()
+        page_size = max(self.TRACE_FILTER_TX_LIMIT * 10, 100)
+        tx_hashes: Set[str] = set()
+        after = 0
 
-        if res is None or not isinstance(res, list):
-            return set()
-        # If provider returns more than our cap, stop early to avoid heavy scans
-        if len(res) > self.TRACE_FILTER_TX_LIMIT:
+        while len(tx_hashes) < self.TRACE_FILTER_TX_LIMIT:
+            try:
+                res = self.w3.tracing.trace_filter(
+                    {
+                        **filter_params,
+                        "count": page_size,
+                        "after": after,
+                    }
+                )
+            except Exception as e:
+                self.logger.error(f"Error filtering transactions: {e}")
+                return set()
+
+            if res is None or not isinstance(res, list) or len(res) == 0:
+                break
+
+            for trace in res:
+                if (
+                    str(trace.get("type", "")).lower()
+                    not in self.ALLOWED_TRACE_TYPES
+                ):
+                    continue
+
+                tx_hash = trace.get("transactionHash")
+                if isinstance(tx_hash, HexBytes):
+                    tx_hash = tx_hash.to_0x_hex()
+                if tx_hash:
+                    tx_hashes.add(tx_hash)
+                if len(tx_hashes) >= self.TRACE_FILTER_TX_LIMIT:
+                    break
+
+            if len(res) < page_size:
+                break
+            after += len(res)
+
+        if len(tx_hashes) >= self.TRACE_FILTER_TX_LIMIT:
             self.logger.warning(
-                f"trace_filter returned {len(res)} results (> {self.TRACE_FILTER_TX_LIMIT}). Capping to limit."
+                "trace_filter reached the transaction cap of %s unique transactions.",
+                self.TRACE_FILTER_TX_LIMIT,
             )
-            res = res[: self.TRACE_FILTER_TX_LIMIT]
-        allowed = {"call", "delegatecall", "staticcall", "callcode"}
-        tx_hashes = {
-            (
-                r["transactionHash"].to_0x_hex()
-                if type(r["transactionHash"]) is HexBytes
-                else r["transactionHash"]
-            )
-            for r in res
-            if str(r.get("type", "")).lower() in allowed
-        }
         self.logger.info(f"Found {len(tx_hashes)} transactions.")
         return tx_hashes
 

--- a/webapp/backend/crystal-clear/tests/traces/test_trace_collector.py
+++ b/webapp/backend/crystal-clear/tests/traces/test_trace_collector.py
@@ -100,6 +100,35 @@ def test_filter_txs_from(MockWeb3, trace_collector):
 
 
 @patch("web3.Web3")
+def test_filter_txs_from_collects_unique_transactions_before_capping(
+    MockWeb3, trace_collector
+):
+    mock_w3_instance = MockWeb3.return_value
+    duplicate_traces = [
+        {"transactionHash": "0xdup", "type": "call"} for _ in range(100)
+    ]
+    mock_w3_instance.tracing.trace_filter.side_effect = [
+        duplicate_traces,
+        [{"transactionHash": "0xnext", "type": "call"}],
+    ]
+
+    trace_collector.w3 = mock_w3_instance
+
+    tx_hashes = trace_collector._filter_txs_from(1, 10, "0x123")
+
+    assert tx_hashes == {"0xdup", "0xnext"}
+    assert mock_w3_instance.tracing.trace_filter.call_args_list[0].args[0][
+        "after"
+    ] == 0
+    assert mock_w3_instance.tracing.trace_filter.call_args_list[0].args[0][
+        "count"
+    ] == 100
+    assert mock_w3_instance.tracing.trace_filter.call_args_list[1].args[0][
+        "after"
+    ] == 100
+
+
+@patch("web3.Web3")
 def test_get_calls_from_tx(MockWeb3, trace_collector):
     mock_w3_instance = MockWeb3.return_value
     mock_w3_instance.geth.debug.trace_transaction.return_value = {"calls": []}


### PR DESCRIPTION
## Summary
- page trace_filter results while collecting unique transaction hashes for dependency analysis
- cap on unique transactions instead of raw trace rows so duplicate traces from one tx do not crowd out the rest of the supply chain
- add a regression test covering paginated duplicate traces

## Testing
- cd webapp/backend/crystal-clear && pytest -q tests/traces/test_trace_collector.py tests/simulations/test_simulation_collector.py

Closes #276