### PR TITLE
add  CI/CD workflows for pellow backfill

### DIFF
--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -1,9 +1,8 @@
 on:
   push:
-    # branches: [main]
-    # paths:
-    #   - "webapp/backend/tools/backfill**"
-    branches: [chore/cd-for-backfill-pellow]
+    branches: [main]
+    paths:
+      - "webapp/backend/tools/backfill**"
 
 jobs:
   deploy:

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches: [main]
+    paths:
+      - "webapp/backend/tools/backfill**"
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, pellow]
+    steps:
+      - name: Pull latest code
+        run: |
+          cd /home/javier/crystal-clear
+          git pull
+
+      - name: Restart backfill
+        run: sudo systemctl restart crystal-clear-backfill

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -8,6 +8,9 @@ jobs:
   deploy:
     runs-on: [self-hosted, pellow]
     steps:
+      - name: Test connection
+        run: echo "Runner is working on pellow"
+
       - name: Pull latest code
         run: |
           cd /home/javier/crystal-clear

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -1,8 +1,9 @@
 on:
   push:
-    branches: [main]
-    paths:
-      - "webapp/backend/tools/backfill**"
+    # branches: [main]
+    # paths:
+    #   - "webapp/backend/tools/backfill**"
+    branches: [chore/cd-for-backfill-pellow]
 
 jobs:
   deploy:

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, pellow]
+    runs-on: [self-hosted]
     steps:
       - name: Test connection
         run: echo "Runner is working on pellow"

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Pull latest code
         run: |
-          sudo -u javier git -C /home/javier/crystal-clear pull
+          git -C /home/raphina/crystal-clear pull
 
       - name: Restart backfill
         run: sudo systemctl restart crystal-clear-backfill

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Pull latest code
         run: |
-          cd /home/javier/crystal-clear
-          git pull
+          sudo -u javier git -C /home/javier/crystal-clear pull
 
       - name: Restart backfill
         run: sudo systemctl restart crystal-clear-backfill

--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -542,11 +542,8 @@ async def simulate_transaction(
             ok_reason = "EIP-7702 delegated EOA (verified delegate)"
         elif call_object.get("to") and not touched_addresses:
             ok_reason = "to EOA"
-<<<<<<< HEAD
         elif _has_allowlisted_verification(items):
             ok_reason = "allowlist"
-=======
->>>>>>> 184cb8b (feat: add eip7702 in details)
         else:
             ok_reason = None
     interaction_status = _build_interaction_status(
@@ -975,11 +972,8 @@ async def get_tx_risk_from_raw(
             ok_reason = "EIP-7702 delegated EOA (verified delegate)"
         elif call_object.get("to") and not touched_addresses:
             ok_reason = "to EOA"
-<<<<<<< HEAD
         elif _has_allowlisted_verification(items):
             ok_reason = "allowlist"
-=======
->>>>>>> 184cb8b (feat: add eip7702 in details)
         else:
             ok_reason = None
     interaction_status = _build_interaction_status(

--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -542,8 +542,11 @@ async def simulate_transaction(
             ok_reason = "EIP-7702 delegated EOA (verified delegate)"
         elif call_object.get("to") and not touched_addresses:
             ok_reason = "to EOA"
+<<<<<<< HEAD
         elif _has_allowlisted_verification(items):
             ok_reason = "allowlist"
+=======
+>>>>>>> 184cb8b (feat: add eip7702 in details)
         else:
             ok_reason = None
     interaction_status = _build_interaction_status(
@@ -972,8 +975,11 @@ async def get_tx_risk_from_raw(
             ok_reason = "EIP-7702 delegated EOA (verified delegate)"
         elif call_object.get("to") and not touched_addresses:
             ok_reason = "to EOA"
+<<<<<<< HEAD
         elif _has_allowlisted_verification(items):
             ok_reason = "allowlist"
+=======
+>>>>>>> 184cb8b (feat: add eip7702 in details)
         else:
             ok_reason = None
     interaction_status = _build_interaction_status(

--- a/webapp/backend/src/api/schemas/analysis.py
+++ b/webapp/backend/src/api/schemas/analysis.py
@@ -349,17 +349,6 @@ class SimulationResultItem(BaseModel):
             "Verification data refers to this delegate contract."
         ),
     )
-    is_eip7702: bool = Field(
-        False,
-        description="Whether this address is an EIP-7702 delegated EOA",
-    )
-    delegate_address: Optional[str] = Field(
-        None,
-        description=(
-            "Delegate contract address for EIP-7702 delegated EOAs. "
-            "Verification data refers to this delegate contract."
-        ),
-    )
 
 
 class SimulationResponse(BaseModel):
@@ -414,7 +403,20 @@ class SimulationResponse(BaseModel):
         description=(
             "Root cause of a non-OK verdict. FIRST_TIME_INTERACTION = sender/contract "
             "has never called this address; MISSING_HISTORY = no historical scan data "
-            "available; UNVERIFIED = contract source code is not verified on-chain."
+            "available; UNVERIFIED = contract source code is not verified on-chain; "
+            "EIP_7702_UNVERIFIED_DELEGATE = the destination is an EIP-7702 delegated "
+            "EOA whose delegate contract is not verified."
+        ),
+    )
+    ok_reason: Optional[
+        Literal["to EOA", "EIP-7702 delegated EOA (verified delegate)"]
+    ] = Field(
+        None,
+        description=(
+            "Reason the verdict is OK when the transaction touches no contracts. "
+            "to EOA = the destination address has no bytecode (plain ETH transfer). "
+            "EIP-7702 delegated EOA (verified delegate) = destination is an EIP-7702 "
+            "delegated EOA whose delegate contract is verified."
         ),
     )
     ok_reason: Optional[


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate deployment for the `backfill` tool in the backend. The workflow is triggered on pushes to the `main` branch that affect files under `webapp/backend/tools/backfill`, and it ensures the latest code is pulled and the relevant service is restarted on a self-hosted runner.

Deployment automation:

* Added `.github/workflows/pellow-backfill-deploy.yml` to automatically deploy backend `backfill` tool changes by pulling the latest code and restarting the `crystal-clear-backfill` service on pushes to `main`.