### PR TITLE
Update user to ccprod and fix script permissions

### DIFF
--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -1,9 +1,9 @@
 on:
   push:
-#    branches: [main]
-#    paths:
-#      - "webapp/backend/tools/backfill**"
-    branches: [chore/change-user-pellow]
+    branches: [main]
+    paths:
+      - "webapp/backend/tools/backfill**"
+
 jobs:
   deploy:
     runs-on: [self-hosted, pellow-backfill-on-cc-prod]
@@ -16,4 +16,4 @@ jobs:
           git -C /home/crystal-clear-prod/crystal-clear pull
 
       - name: Restart backfill
-        run: sudo /home/crystal-clear-prod/restart-backfill.sh 
+        run: sudo /home/crystal-clear-prod/restart-backfill.sh

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -16,4 +16,4 @@ jobs:
           git -C /home/crystal-clear-prod/crystal-clear pull
 
       - name: Restart backfill
-        run: /home/crystal-clear-prod/restart-backfill.sh 
+        run: sudo /home/crystal-clear-prod/restart-backfill.sh 

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -2,7 +2,7 @@ on:
   push:
 #    branches: [main]
 #    paths:
-      - "webapp/backend/tools/backfill**"
+#      - "webapp/backend/tools/backfill**"
     branches: [chore/change-user-pellow]
 jobs:
   deploy:

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -1,19 +1,19 @@
 on:
   push:
-    branches: [main]
-    paths:
+#    branches: [main]
+#    paths:
       - "webapp/backend/tools/backfill**"
-
+    branches: [chore/change-user-pellow]
 jobs:
   deploy:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, pellow-backfill-on-cc-prod]
     steps:
       - name: Test connection
         run: echo "Runner is working on pellow"
 
       - name: Pull latest code
         run: |
-          git -C /home/raphina/crystal-clear pull
+          git -C /home/crystal-clear-prod/crystal-clear pull
 
       - name: Restart backfill
-        run: sudo systemctl restart crystal-clear-backfill
+        run: /home/crystal-clear-prod/restart-backfill.sh

--- a/.github/workflows/pellow-backfill-deploy.yml
+++ b/.github/workflows/pellow-backfill-deploy.yml
@@ -16,4 +16,4 @@ jobs:
           git -C /home/crystal-clear-prod/crystal-clear pull
 
       - name: Restart backfill
-        run: /home/crystal-clear-prod/restart-backfill.sh
+        run: /home/crystal-clear-prod/restart-backfill.sh 


### PR DESCRIPTION
This pull request updates the deployment workflow for the pellow backfill job to better align with the production environment setup. The main changes involve specifying a more targeted runner, updating the code pull path, and changing the restart command to use a custom script.

Deployment workflow updates:

* Changed the `runs-on` specification to use the `pellow-backfill-on-cc-prod` runner label for more precise targeting.
* Updated the path for pulling the latest code to `/home/crystal-clear-prod/crystal-clear` to reflect the production directory structure.
* Modified the backfill restart step to use the custom script `/home/crystal-clear-prod/restart-backfill.sh` instead of directly calling `systemctl`.

related to #293 