### PR TITLE
Add continuous deployment for Pellow API on main push

### DIFF
--- a/.github/workflows/pellow-backend-deploy.yml
+++ b/.github/workflows/pellow-backend-deploy.yml
@@ -1,7 +1,6 @@
 on:
   push:
-#    branches: [main]
-    branches: chore/pellow-backend-cd
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/pellow-backend-deploy.yml
+++ b/.github/workflows/pellow-backend-deploy.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+#    branches: [main]
+    branches: chore/pellow-backend-cd
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, pellow-backend-api-on-cc-prod]
+    steps:
+      - name: Pull latest code
+        run: |
+          git -C /home/crystal-clear-prod/crystal-clear pull
+
+      - name: Restart backend
+        run: sudo /home/crystal-clear-prod/restart-backend.sh


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployment of the backend when changes are pushed to the `main` branch. The workflow pulls the latest code and restarts the backend service on the production server.

Deployment automation:

* Added a new workflow file `.github/workflows/pellow-backend-deploy.yml` that triggers on pushes to `main`, pulls the latest code to the production directory, and restarts the backend service using a shell script.

closes #293 