### PR TITLE
feat: add tx-risk-hash endpoint

### DIFF
--- a/webapp/backend/src/api/integrations/crystal_clear_adapter.py
+++ b/webapp/backend/src/api/integrations/crystal_clear_adapter.py
@@ -79,6 +79,15 @@ class CrystalClearRiskEngine(RiskEngine):
             latest_offset=latest_offset,
         )
 
+    def get_transaction(self, tx_hash: str) -> dict[str, Any]:
+        sc = self._client.simulation_collector
+        if sc is None:
+            raise ValueError("SimulationCollector is not initialized.")
+        from hexbytes import HexBytes
+
+        tx = sc.w3.eth.get_transaction(HexBytes(tx_hash))
+        return dict(tx)
+
 
 @lru_cache(maxsize=1)
 def get_risk_engine() -> RiskEngine:

--- a/webapp/backend/src/api/integrations/risk_engine.py
+++ b/webapp/backend/src/api/integrations/risk_engine.py
@@ -35,3 +35,6 @@ class RiskEngine(Protocol):
         latest_offset: int | None = None,
     ) -> dict[str, Any]:
         """Simulate an on-chain transaction by hash."""
+
+    def get_transaction(self, tx_hash: str) -> dict[str, Any]:
+        """Fetch a transaction from the chain by hash and return its fields."""

--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -673,7 +673,7 @@ async def get_tx_risk(
 
 
 @router.get(
-    "/tx-risk-has/{tx_hash}",
+    "/tx-risk-hash/{tx_hash}",
     response_model=SimulationResponse,
     responses={
         500: {
@@ -692,7 +692,7 @@ async def get_tx_risk(
         "list all touched contracts (including DELEGATECALL), and report risk identically to tx-risk-raw."
     ),
 )
-async def get_tx_risk_has(
+async def get_tx_risk_hash(
     tx_hash: str,
     interaction_type: Optional[
         Literal[
@@ -792,9 +792,9 @@ async def get_tx_risk_has(
             root_contract=call_object.get("to"),
             touched_addresses=touched_addresses,
         )
-        logger.info("tx-risk-has seeded interaction_scan_state rows: {}", seeded_rows)
+        logger.info("tx-risk-hash seeded interaction_scan_state rows: {}", seeded_rows)
     except Exception as exc:
-        logger.warning("tx-risk-has failed to seed interaction_scan_state: {}", exc)
+        logger.warning("tx-risk-hash failed to seed interaction_scan_state: {}", exc)
 
     (
         interaction_first_time,

--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -35,7 +35,7 @@ from src.api.integrations.risk_engine import RiskEngine
 from eth_account import Account
 from eth_account.typed_transactions import TypedTransaction
 from hexbytes import HexBytes
-from typing import Optional, Any, Dict, List, Union
+from typing import Literal, Optional, Any, Dict, List, Union
 import rlp
 from loguru import logger
 
@@ -668,6 +668,205 @@ async def get_tx_risk(
     return SimulationResponse(
         status=status,
         details=items,
+        ok_reason=ok_reason,
+    )
+
+
+@router.get(
+    "/tx-risk-has/{tx_hash}",
+    response_model=SimulationResponse,
+    responses={
+        500: {
+            "description": "Internal server error",
+            "model": ErrorResponse,
+        },
+        422: {
+            "description": "Input validation error",
+            "model": ErrorResponse,
+        },
+    },
+    status_code=status.HTTP_200_OK,
+    summary="Transaction risk: from existing on-chain transaction",
+    description=(
+        "Fetch an existing mainnet transaction by hash, simulate it at its block, "
+        "list all touched contracts (including DELEGATECALL), and report risk identically to tx-risk-raw."
+    ),
+)
+async def get_tx_risk_has(
+    tx_hash: str,
+    interaction_type: Optional[
+        Literal[
+            "sender_direct",
+            "sender_transitive",
+            "contract_direct",
+            "contract_transitive",
+        ]
+    ] = Query(None, description="Interaction type to check"),
+    latest_offset: Optional[int] = Query(
+        100, description="Limit first-time checks to N latest blocks"
+    ),
+    risk_engine: RiskEngine = Depends(get_risk_engine),
+    session: Session = Depends(get_session),
+) -> SimulationResponse:
+    tx_hash = _validate_tx_hash(tx_hash)
+
+    try:
+        tx = risk_engine.get_transaction(tx_hash)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422, detail=f"Failed to fetch transaction: {exc}"
+        ) from exc
+
+    def _hex_field(val: Any) -> Optional[str]:
+        if val is None:
+            return None
+        if isinstance(val, (bytes, bytearray)):
+            return "0x" + val.hex()
+        if isinstance(val, int):
+            return hex(val)
+        return str(val)
+
+    sender = _hex_field(tx.get("from")) or ""
+    if not sender.startswith("0x"):
+        raise HTTPException(status_code=422, detail="Transaction has no sender")
+
+    call_object: Dict[str, Any] = {"from": sender}
+    to_val = tx.get("to")
+    if to_val is not None and to_val != b"":
+        call_object["to"] = _hex_field(to_val)
+    data_val = tx.get("input") or tx.get("data")
+    if data_val is not None:
+        call_object["data"] = _hex_field(data_val)
+    value_val = tx.get("value")
+    if value_val is not None:
+        call_object["value"] = hex(int(value_val))
+    gas_val = tx.get("gas")
+    if gas_val is not None:
+        call_object["gas"] = hex(int(gas_val))
+    gas_price_val = tx.get("gasPrice")
+    if gas_price_val is not None:
+        call_object["gasPrice"] = hex(int(gas_price_val))
+    mp_val = tx.get("maxPriorityFeePerGas")
+    if mp_val is not None:
+        call_object["maxPriorityFeePerGas"] = hex(int(mp_val))
+    mf_val = tx.get("maxFeePerGas")
+    if mf_val is not None:
+        call_object["maxFeePerGas"] = hex(int(mf_val))
+    tx_type_raw = tx.get("type")
+    if tx_type_raw is not None:
+        call_object["type"] = hex(int(tx_type_raw))
+
+    block_number: Optional[int] = tx.get("blockNumber")
+    block_tag: str = hex(block_number) if block_number else "latest"
+    to_block: Optional[str] = hex(block_number - 1) if block_number and block_number > 0 else None
+
+    results = risk_engine.simulate_and_check(
+        call_object,
+        block_tag=block_tag,
+        from_block=None,
+        to_block=to_block,
+        latest_offset=latest_offset,
+    )
+    touched_addresses = list(results.keys())
+    checked_interaction_types = _resolve_checked_interaction_types(
+        [interaction_type] if interaction_type else None,
+        call_object.get("to"),
+    )
+
+    items = [
+        {
+            "address": addr,
+            "verification": info.get("verification"),
+            "depth": info.get("depth"),
+            "types": info.get("types"),
+            "is_eip7702": info.get("is_eip7702", False),
+            "delegate_address": info.get("delegate_address"),
+        }
+        for addr, info in results.items()
+    ]
+
+    try:
+        seeded_rows = seed_interaction_scan_state_from_tx(
+            session=session,
+            sender_address=sender,
+            root_contract=call_object.get("to"),
+            touched_addresses=touched_addresses,
+        )
+        logger.info("tx-risk-has seeded interaction_scan_state rows: {}", seeded_rows)
+    except Exception as exc:
+        logger.warning("tx-risk-has failed to seed interaction_scan_state: {}", exc)
+
+    (
+        interaction_first_time,
+        interaction_state,
+        contract_dangerous_types,
+        sender_dangerous_types,
+        contract_missing_types,
+        sender_missing_types,
+    ) = _evaluate_interaction_scan_risk(
+        session=session,
+        sender_address=sender,
+        root_contract=call_object.get("to"),
+        touched_addresses=touched_addresses,
+        checked_interaction_types=checked_interaction_types,
+    )
+    for item in items:
+        normalized = _normalize_address(item["address"]) or ""
+        first_time_by_type = interaction_first_time.get(normalized, {})
+        item["interaction_first_time"] = first_time_by_type
+        item["interaction_state"] = interaction_state.get(normalized, {})
+        item["first_time"] = any(first_time_by_type.values())
+
+    eip7702_unverified = any(
+        item.get("is_eip7702")
+        and item.get("verification", {}).get("verification") == "not-verified"
+        for item in items
+    )
+    eip7702_verified = any(
+        item.get("is_eip7702")
+        and item.get("verification", {}).get("verification") != "not-verified"
+        for item in items
+    )
+
+    if _has_unverified_dangerous(items):
+        status_val = "DANGEROUS"
+        danger_reason = "UNVERIFIED"
+        ok_reason = None
+    elif eip7702_unverified:
+        status_val = "DANGEROUS"
+        danger_reason = "EIP_7702_UNVERIFIED_DELEGATE"
+        ok_reason = None
+    elif contract_dangerous_types:
+        status_val = "DANGEROUS"
+        danger_reason = "FIRST_TIME_INTERACTION"
+        ok_reason = None
+    elif contract_missing_types:
+        status_val = "POTENTIAL_DANGEROUS"
+        danger_reason = "MISSING_HISTORY"
+        ok_reason = None
+    else:
+        status_val = "OK"
+        danger_reason = None
+        if eip7702_verified:
+            ok_reason = "EIP-7702 delegated EOA (verified delegate)"
+        elif call_object.get("to") and not touched_addresses:
+            ok_reason = "to EOA"
+        elif _has_allowlisted_verification(items):
+            ok_reason = "allowlist"
+        else:
+            ok_reason = None
+
+    interaction_status = _build_interaction_status(
+        checked_interaction_types,
+        contract_dangerous_types + sender_dangerous_types,
+        contract_missing_types + sender_missing_types,
+    )
+    return SimulationResponse(
+        status=status_val,
+        interaction_status=interaction_status,
+        details=items,
+        dangerous_interaction_types=contract_dangerous_types,
+        danger_reason=danger_reason,
         ok_reason=ok_reason,
     )
 

--- a/webapp/backend/tests/routers/test_analysis_tx_risk_has.py
+++ b/webapp/backend/tests/routers/test_analysis_tx_risk_has.py
@@ -1,0 +1,180 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.core.database import get_session
+from src.api.integrations.crystal_clear_adapter import get_risk_engine
+from src.api.routers import analysis
+
+_TX_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_SENDER = "0x1111111111111111111111111111111111111111"
+_CONTRACT = "0x2222222222222222222222222222222222222222"
+_BLOCK = 21000000
+
+_FAKE_TX = {
+    "from": _SENDER,
+    "to": _CONTRACT,
+    "input": b"",
+    "value": 0,
+    "gas": 21000,
+    "gasPrice": 1000000000,
+    "blockNumber": _BLOCK,
+    "type": 0,
+}
+
+
+class _FakeRiskEngine:
+    def __init__(self, tx=None, simulate_result=None, raise_get_tx=False):
+        self._tx = tx if tx is not None else _FAKE_TX
+        self._simulate_result = simulate_result or {
+            _CONTRACT: {
+                "verification": {"verification": "verified"},
+                "depth": 1,
+                "types": {"CALL": 1},
+                "is_eip7702": False,
+                "delegate_address": None,
+            }
+        }
+        self._raise_get_tx = raise_get_tx
+
+    def get_transaction(self, tx_hash):
+        if self._raise_get_tx:
+            raise RuntimeError("node unavailable")
+        return self._tx
+
+    def simulate_and_check(self, call_object, **kwargs):
+        self._last_call = (call_object, kwargs)
+        return self._simulate_result
+
+
+def _build_client(engine=None) -> TestClient:
+    app = FastAPI()
+    app.include_router(analysis.router)
+    app.dependency_overrides[get_risk_engine] = lambda: (
+        engine if engine is not None else _FakeRiskEngine()
+    )
+    app.dependency_overrides[get_session] = lambda: object()
+    return TestClient(app)
+
+
+def _patch_interaction_helpers(
+    monkeypatch,
+    contract_dangerous_types=None,
+    sender_dangerous_types=None,
+    contract_missing_types=None,
+    sender_missing_types=None,
+    interaction_first_time=None,
+    interaction_state=None,
+):
+    monkeypatch.setattr(analysis, "seed_interaction_scan_state_from_tx", lambda **_k: 0)
+    monkeypatch.setattr(
+        analysis,
+        "_evaluate_interaction_scan_risk",
+        lambda **_k: (
+            interaction_first_time or {},
+            interaction_state or {},
+            contract_dangerous_types or [],
+            sender_dangerous_types or [],
+            contract_missing_types or [],
+            sender_missing_types or [],
+        ),
+    )
+
+
+def test_tx_risk_has_invalid_hash():
+    client = _build_client()
+    response = client.get("/v1/analysis/tx-risk-has/not-a-hash")
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Invalid tx_hash format"
+
+
+def test_tx_risk_has_get_transaction_failure():
+    engine = _FakeRiskEngine(raise_get_tx=True)
+    client = _build_client(engine)
+    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    assert response.status_code == 422
+    assert "Failed to fetch transaction" in response.json()["detail"]
+
+
+def test_tx_risk_has_ok_status(monkeypatch):
+    _patch_interaction_helpers(monkeypatch)
+    client = _build_client()
+    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "OK"
+    assert isinstance(data["details"], list)
+    assert len(data["details"]) == 1
+    assert data["details"][0]["address"] == _CONTRACT
+
+
+def test_tx_risk_has_dangerous_first_time(monkeypatch):
+    _patch_interaction_helpers(
+        monkeypatch,
+        contract_dangerous_types=["contract_direct"],
+        interaction_first_time={_CONTRACT.lower(): {"contract_direct": True}},
+        interaction_state={_CONTRACT.lower(): {"contract_direct": "FOUND"}},
+    )
+    client = _build_client()
+    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "DANGEROUS"
+    assert data["danger_reason"] == "FIRST_TIME_INTERACTION"
+
+
+def test_tx_risk_has_dangerous_unverified(monkeypatch):
+    engine = _FakeRiskEngine(
+        simulate_result={
+            _CONTRACT: {
+                "verification": {"verification": "not-verified"},
+                "depth": 1,
+                "types": {"CALL": 1},
+                "is_eip7702": False,
+                "delegate_address": None,
+            }
+        }
+    )
+    _patch_interaction_helpers(monkeypatch)
+    client = _build_client(engine)
+    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "DANGEROUS"
+    assert data["danger_reason"] == "UNVERIFIED"
+
+
+def test_tx_risk_has_uses_tx_block_tag(monkeypatch):
+    _patch_interaction_helpers(monkeypatch)
+    engine = _FakeRiskEngine()
+    client = _build_client(engine)
+    client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    call_object, kwargs = engine._last_call
+    assert kwargs["block_tag"] == hex(_BLOCK)
+    assert kwargs["to_block"] == hex(_BLOCK - 1)
+
+
+def test_tx_risk_has_response_shape_matches_tx_risk_raw(monkeypatch):
+    """Verify the response includes the same top-level fields as tx-risk-raw."""
+    _patch_interaction_helpers(monkeypatch)
+    client = _build_client()
+    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    assert response.status_code == 200
+    data = response.json()
+    for field in ("status", "interaction_status", "details", "dangerous_interaction_types", "danger_reason", "ok_reason"):
+        assert field in data, f"Missing field: {field}"
+    item = data["details"][0]
+    for field in ("address", "verification", "depth", "types", "first_time", "interaction_first_time", "interaction_state"):
+        assert field in item, f"Missing item field: {field}"
+
+
+def test_tx_risk_has_missing_block_number_uses_latest(monkeypatch):
+    tx_no_block = {**_FAKE_TX, "blockNumber": None}
+    engine = _FakeRiskEngine(tx=tx_no_block)
+    _patch_interaction_helpers(monkeypatch)
+    client = _build_client(engine)
+    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    assert response.status_code == 200
+    _, kwargs = engine._last_call
+    assert kwargs["block_tag"] == "latest"
+    assert kwargs["to_block"] is None

--- a/webapp/backend/tests/routers/test_analysis_tx_risk_hash.py
+++ b/webapp/backend/tests/routers/test_analysis_tx_risk_hash.py
@@ -81,25 +81,25 @@ def _patch_interaction_helpers(
     )
 
 
-def test_tx_risk_has_invalid_hash():
+def test_tx_risk_hash_invalid_hash():
     client = _build_client()
-    response = client.get("/v1/analysis/tx-risk-has/not-a-hash")
+    response = client.get("/v1/analysis/tx-risk-hash/not-a-hash")
     assert response.status_code == 422
     assert response.json()["detail"] == "Invalid tx_hash format"
 
 
-def test_tx_risk_has_get_transaction_failure():
+def test_tx_risk_hash_get_transaction_failure():
     engine = _FakeRiskEngine(raise_get_tx=True)
     client = _build_client(engine)
-    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    response = client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     assert response.status_code == 422
     assert "Failed to fetch transaction" in response.json()["detail"]
 
 
-def test_tx_risk_has_ok_status(monkeypatch):
+def test_tx_risk_hash_ok_status(monkeypatch):
     _patch_interaction_helpers(monkeypatch)
     client = _build_client()
-    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    response = client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "OK"
@@ -108,7 +108,7 @@ def test_tx_risk_has_ok_status(monkeypatch):
     assert data["details"][0]["address"] == _CONTRACT
 
 
-def test_tx_risk_has_dangerous_first_time(monkeypatch):
+def test_tx_risk_hash_dangerous_first_time(monkeypatch):
     _patch_interaction_helpers(
         monkeypatch,
         contract_dangerous_types=["contract_direct"],
@@ -116,14 +116,14 @@ def test_tx_risk_has_dangerous_first_time(monkeypatch):
         interaction_state={_CONTRACT.lower(): {"contract_direct": "FOUND"}},
     )
     client = _build_client()
-    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    response = client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "DANGEROUS"
     assert data["danger_reason"] == "FIRST_TIME_INTERACTION"
 
 
-def test_tx_risk_has_dangerous_unverified(monkeypatch):
+def test_tx_risk_hash_dangerous_unverified(monkeypatch):
     engine = _FakeRiskEngine(
         simulate_result={
             _CONTRACT: {
@@ -137,28 +137,28 @@ def test_tx_risk_has_dangerous_unverified(monkeypatch):
     )
     _patch_interaction_helpers(monkeypatch)
     client = _build_client(engine)
-    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    response = client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "DANGEROUS"
     assert data["danger_reason"] == "UNVERIFIED"
 
 
-def test_tx_risk_has_uses_tx_block_tag(monkeypatch):
+def test_tx_risk_hash_uses_tx_block_tag(monkeypatch):
     _patch_interaction_helpers(monkeypatch)
     engine = _FakeRiskEngine()
     client = _build_client(engine)
-    client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     call_object, kwargs = engine._last_call
     assert kwargs["block_tag"] == hex(_BLOCK)
     assert kwargs["to_block"] == hex(_BLOCK - 1)
 
 
-def test_tx_risk_has_response_shape_matches_tx_risk_raw(monkeypatch):
+def test_tx_risk_hash_response_shape_matches_tx_risk_raw(monkeypatch):
     """Verify the response includes the same top-level fields as tx-risk-raw."""
     _patch_interaction_helpers(monkeypatch)
     client = _build_client()
-    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    response = client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     assert response.status_code == 200
     data = response.json()
     for field in ("status", "interaction_status", "details", "dangerous_interaction_types", "danger_reason", "ok_reason"):
@@ -168,12 +168,12 @@ def test_tx_risk_has_response_shape_matches_tx_risk_raw(monkeypatch):
         assert field in item, f"Missing item field: {field}"
 
 
-def test_tx_risk_has_missing_block_number_uses_latest(monkeypatch):
+def test_tx_risk_hash_missing_block_number_uses_latest(monkeypatch):
     tx_no_block = {**_FAKE_TX, "blockNumber": None}
     engine = _FakeRiskEngine(tx=tx_no_block)
     _patch_interaction_helpers(monkeypatch)
     client = _build_client(engine)
-    response = client.get(f"/v1/analysis/tx-risk-has/{_TX_HASH}")
+    response = client.get(f"/v1/analysis/tx-risk-hash/{_TX_HASH}")
     assert response.status_code == 200
     _, kwargs = engine._last_call
     assert kwargs["block_tag"] == "latest"


### PR DESCRIPTION
## Summary

- Adds `GET /v1/analysis/tx-risk-hash/{tx_hash}` endpoint that fetches an existing mainnet transaction by hash and returns risk analysis in the exact same `SimulationResponse` shape as `tx-risk-raw`
- Adds `get_transaction()` to the `RiskEngine` protocol and `CrystalClearRiskEngine` adapter to fetch raw tx fields (from, to, input, value, gas, blockNumber, etc.) from the chain
- The tx is replayed via `simulate_and_check` at its own block (`block_tag=hex(blockNumber)`) with `to_block=hex(blockNumber-1)` for interaction history checks — same semantics as `simulate_from_tx` but producing the full rich response
- Seeds `interaction_scan_state` rows for backfill, evaluates first-time interaction risk, eip7702 checks — identical logic to `tx-risk-raw`

## Test plan

- [x] `test_tx_risk_hash_invalid_hash` — 422 on bad hash format
- [x] `test_tx_risk_hash_get_transaction_failure` — 422 when node call fails
- [x] `test_tx_risk_hash_ok_status` — happy path returns 200 OK
- [x] `test_tx_risk_hash_dangerous_first_time` — DANGEROUS + FIRST_TIME_INTERACTION reason
- [x] `test_tx_risk_hash_dangerous_unverified` — DANGEROUS + UNVERIFIED reason
- [x] `test_tx_risk_hash_uses_tx_block_tag` — block_tag and to_block derived from tx.blockNumber
- [x] `test_tx_risk_hash_response_shape_matches_tx_risk_raw` — all SimulationResponse fields present
- [x] `test_tx_risk_hash_missing_block_number_uses_latest` — falls back to "latest" when blockNumber is None

🤖 Generated with [Claude Code](https://claude.com/claude-code)