### PR TITLE
feat: backward scan and hole-filling for backfill worker

### DIFF
--- a/webapp/backend/src/api/models/interaction_scan_backward_progress.py
+++ b/webapp/backend/src/api/models/interaction_scan_backward_progress.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+class InteractionScanBackwardProgress(SQLModel, table=True):
+    """Tracks backward-scan progress for a (from, to, interaction_type) pair."""
+
+    __tablename__ = "interaction_scan_backward_progress"
+    __table_args__ = (
+        UniqueConstraint(
+            "from_address",
+            "to_address",
+            "interaction_type",
+            name="uq_interaction_scan_backward_progress_pair_type",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    from_address: str = Field(index=True)
+    to_address: str = Field(index=True)
+    interaction_type: str
+    last_backward_block: Optional[int] = Field(
+        default=None,
+        description="Lowest block reached so far; None = scan not yet started",
+    )
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = ["InteractionScanBackwardProgress"]

--- a/webapp/backend/tests/tools/conftest.py
+++ b/webapp/backend/tests/tools/conftest.py
@@ -1,9 +1,0 @@
-"""Minimal env setup so backfill_first_time_interactions_core can be imported in tests."""
-import os
-
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault("CACHE_URL", "redis://localhost:6379")
-os.environ.setdefault("ALLIUM_API_KEY", "test-key")
-os.environ.setdefault("ETHERSCAN_API_KEY", "test-key")
-os.environ.setdefault("ETH_NODE_URL", "http://localhost:8545")
-os.environ.setdefault("ETH_NODE_URLS", "http://localhost:8545")

--- a/webapp/backend/tests/tools/conftest.py
+++ b/webapp/backend/tests/tools/conftest.py
@@ -1,0 +1,9 @@
+"""Minimal env setup so backfill_first_time_interactions_core can be imported in tests."""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("CACHE_URL", "redis://localhost:6379")
+os.environ.setdefault("ALLIUM_API_KEY", "test-key")
+os.environ.setdefault("ETHERSCAN_API_KEY", "test-key")
+os.environ.setdefault("ETH_NODE_URL", "http://localhost:8545")
+os.environ.setdefault("ETH_NODE_URLS", "http://localhost:8545")

--- a/webapp/backend/tests/tools/test_backfill_backward.py
+++ b/webapp/backend/tests/tools/test_backfill_backward.py
@@ -1,29 +1,24 @@
-"""Tests for backward scanning and hole-filling logic in backfill_first_time_interactions_core."""
+"""Tests for backward scan and hole-filling helpers."""
 from __future__ import annotations
 
 import sys
 from pathlib import Path
-from datetime import datetime
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
-if str(TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(TOOLS_DIR))
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+for _p in (str(TOOLS_DIR), str(SRC_DIR.parent)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
-# Import only the pure helpers and models — no Ethereum node needed.
-from backfill_first_time_interactions_core import (  # noqa: E402
-    _resolve_scan_range_backward,
-    _get_backward_progress,
-    _upsert_backward_progress,
-    _fill_skipped_ranges_for_row,
-    _scan_chunk,
-)
-from src.api.models.interaction_scan_backward_progress import (  # noqa: E402
-    InteractionScanBackwardProgress,
+from backfill_backward_helpers import (  # noqa: E402
+    fill_skipped_ranges_for_row,
+    get_backward_progress,
+    resolve_scan_range_backward,
+    upsert_backward_progress,
 )
 from src.api.models.interaction_scan_skipped_range import InteractionScanSkippedRange  # noqa: E402
 from src.api.models.interaction_scan_state import InteractionScanState  # noqa: E402
@@ -39,97 +34,97 @@ def _fresh_db():
 
 
 # ---------------------------------------------------------------------------
-# _resolve_scan_range_backward — pure function, no DB
+# resolve_scan_range_backward — pure function, no DB
 # ---------------------------------------------------------------------------
 
 class TestResolveBackward:
     def test_fresh_row_starts_at_target(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=100, target_block=1000, last_backward_block=None, chunk_size=500
         )
         assert result == (501, 1000)
 
     def test_chunk_does_not_go_below_effective_start(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=100, target_block=1000, last_backward_block=None, chunk_size=2000
         )
         assert result == (100, 1000)
 
     def test_continues_from_last_backward_block(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=0, target_block=1000, last_backward_block=501, chunk_size=200
         )
         # scan_end = 501-1 = 500; scan_start = max(0, 500-200+1) = 301
         assert result == (301, 500)
 
     def test_final_chunk_clips_to_effective_start(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=450, target_block=1000, last_backward_block=501, chunk_size=200
         )
         assert result == (450, 500)
 
     def test_done_when_already_at_effective_start(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=100, target_block=1000, last_backward_block=100, chunk_size=500
         )
         assert result is None
 
     def test_done_when_below_effective_start(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=100, target_block=1000, last_backward_block=50, chunk_size=500
         )
         assert result is None
 
     def test_target_below_effective_start_returns_none(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=500, target_block=200, last_backward_block=None, chunk_size=100
         )
         assert result is None
 
     def test_single_block_range(self):
-        result = _resolve_scan_range_backward(
+        result = resolve_scan_range_backward(
             effective_start=5, target_block=5, last_backward_block=None, chunk_size=100
         )
         assert result == (5, 5)
 
 
 # ---------------------------------------------------------------------------
-# _get_backward_progress / _upsert_backward_progress — DB helpers
+# get_backward_progress / upsert_backward_progress — DB helpers
 # ---------------------------------------------------------------------------
 
 class TestBackwardProgressPersistence:
     def test_returns_none_when_no_record(self):
         with Session(_ENGINE) as session:
-            result = _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
+            result = get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
         assert result is None
 
     def test_upsert_creates_and_retrieves(self):
         with Session(_ENGINE) as session:
-            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 12345)
+            upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 12345)
             session.commit()
-            result = _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
+            result = get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
         assert result == 12345
 
     def test_upsert_updates_existing(self):
         with Session(_ENGINE) as session:
-            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 12345)
+            upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 12345)
             session.commit()
-            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 9000)
+            upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 9000)
             session.commit()
-            result = _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
+            result = get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
         assert result == 9000
 
     def test_different_types_are_independent(self):
         with Session(_ENGINE) as session:
-            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 100)
-            _upsert_backward_progress(session, "0xaaa", "0xbbb", "sender_direct", 200)
+            upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 100)
+            upsert_backward_progress(session, "0xaaa", "0xbbb", "sender_direct", 200)
             session.commit()
-            assert _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct") == 100
-            assert _get_backward_progress(session, "0xaaa", "0xbbb", "sender_direct") == 200
+            assert get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct") == 100
+            assert get_backward_progress(session, "0xaaa", "0xbbb", "sender_direct") == 200
 
 
 # ---------------------------------------------------------------------------
-# _fill_skipped_ranges_for_row
+# fill_skipped_ranges_for_row
 # ---------------------------------------------------------------------------
 
 def _make_scan_state(session: Session, from_addr: str, to_addr: str, itype: str) -> InteractionScanState:
@@ -165,31 +160,39 @@ def _make_hole(
     return hole
 
 
+def _scan_success(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+    return 3, []
+
+
+def _scan_still_fails(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+    return 0, [(scan_start, scan_end)]
+
+
+def _scan_with_hits(hits):
+    def _fn(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+        return hits, []
+    return _fn
+
+
 class TestFillSkippedRanges:
     def test_no_holes_returns_zero(self):
         with Session(_ENGINE) as session:
             row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
             mock_w3 = MagicMock()
-            hits, filled = _fill_skipped_ranges_for_row(
-                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            hits, filled = fill_skipped_ranges_for_row(
+                session, _scan_success, mock_w3, row, 50, "contract_direct", dry_run=False
             )
         assert hits == 0
         assert filled == 0
 
-    def test_successful_retry_removes_hole_and_counts_hits(self, monkeypatch):
-        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
-            return 3, []  # 3 hits, no skipped ranges
-
-        monkeypatch.setattr(
-            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
-        )
+    def test_successful_retry_removes_hole_and_counts_hits(self):
         with Session(_ENGINE) as session:
             row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
             _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
 
             mock_w3 = MagicMock()
-            hits, filled = _fill_skipped_ranges_for_row(
-                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            hits, filled = fill_skipped_ranges_for_row(
+                session, _scan_success, mock_w3, row, 50, "contract_direct", dry_run=False
             )
 
             remaining = session.exec(
@@ -202,20 +205,14 @@ class TestFillSkippedRanges:
         assert filled == 1
         assert len(remaining) == 0
 
-    def test_still_failing_hole_stays_recorded(self, monkeypatch):
-        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
-            return 0, [(scan_start, scan_end)]  # still fails
-
-        monkeypatch.setattr(
-            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
-        )
+    def test_still_failing_hole_stays_recorded(self):
         with Session(_ENGINE) as session:
             row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
             _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
 
             mock_w3 = MagicMock()
-            hits, filled = _fill_skipped_ranges_for_row(
-                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            hits, filled = fill_skipped_ranges_for_row(
+                session, _scan_still_fails, mock_w3, row, 50, "contract_direct", dry_run=False
             )
 
             remaining = session.exec(
@@ -228,20 +225,14 @@ class TestFillSkippedRanges:
         assert filled == 0
         assert len(remaining) == 1
 
-    def test_dry_run_does_not_delete_hole(self, monkeypatch):
-        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
-            return 5, []
-
-        monkeypatch.setattr(
-            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
-        )
+    def test_dry_run_does_not_delete_hole(self):
         with Session(_ENGINE) as session:
             row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
             _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
 
             mock_w3 = MagicMock()
-            hits, filled = _fill_skipped_ranges_for_row(
-                session, mock_w3, row, 50, "contract_direct", dry_run=True
+            hits, filled = fill_skipped_ranges_for_row(
+                session, _scan_success, mock_w3, row, 50, "contract_direct", dry_run=True
             )
 
             remaining = session.exec(
@@ -250,17 +241,11 @@ class TestFillSkippedRanges:
                 )
             ).all()
 
-        assert hits == 5
+        assert hits == 3
         assert filled == 1
         assert len(remaining) == 1  # hole preserved in dry-run
 
-    def test_successful_retry_updates_how_many_times(self, monkeypatch):
-        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
-            return 7, []
-
-        monkeypatch.setattr(
-            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
-        )
+    def test_successful_retry_updates_how_many_times(self):
         with Session(_ENGINE) as session:
             row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
             row.how_many_times = 2
@@ -269,8 +254,8 @@ class TestFillSkippedRanges:
             _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
 
             mock_w3 = MagicMock()
-            _fill_skipped_ranges_for_row(
-                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            fill_skipped_ranges_for_row(
+                session, _scan_with_hits(7), mock_w3, row, 50, "contract_direct", dry_run=False
             )
             session.refresh(row)
 

--- a/webapp/backend/tests/tools/test_backfill_backward.py
+++ b/webapp/backend/tests/tools/test_backfill_backward.py
@@ -1,0 +1,277 @@
+"""Tests for backward scanning and hole-filling logic in backfill_first_time_interactions_core."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from datetime import datetime
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+# Import only the pure helpers and models — no Ethereum node needed.
+from backfill_first_time_interactions_core import (  # noqa: E402
+    _resolve_scan_range_backward,
+    _get_backward_progress,
+    _upsert_backward_progress,
+    _fill_skipped_ranges_for_row,
+    _scan_chunk,
+)
+from src.api.models.interaction_scan_backward_progress import (  # noqa: E402
+    InteractionScanBackwardProgress,
+)
+from src.api.models.interaction_scan_skipped_range import InteractionScanSkippedRange  # noqa: E402
+from src.api.models.interaction_scan_state import InteractionScanState  # noqa: E402
+
+_ENGINE = create_engine("sqlite:///:memory:")
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db():
+    SQLModel.metadata.create_all(_ENGINE)
+    yield
+    SQLModel.metadata.drop_all(_ENGINE)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_scan_range_backward — pure function, no DB
+# ---------------------------------------------------------------------------
+
+class TestResolveBackward:
+    def test_fresh_row_starts_at_target(self):
+        result = _resolve_scan_range_backward(
+            effective_start=100, target_block=1000, last_backward_block=None, chunk_size=500
+        )
+        assert result == (501, 1000)
+
+    def test_chunk_does_not_go_below_effective_start(self):
+        result = _resolve_scan_range_backward(
+            effective_start=100, target_block=1000, last_backward_block=None, chunk_size=2000
+        )
+        assert result == (100, 1000)
+
+    def test_continues_from_last_backward_block(self):
+        result = _resolve_scan_range_backward(
+            effective_start=0, target_block=1000, last_backward_block=501, chunk_size=200
+        )
+        # scan_end = 501-1 = 500; scan_start = max(0, 500-200+1) = 301
+        assert result == (301, 500)
+
+    def test_final_chunk_clips_to_effective_start(self):
+        result = _resolve_scan_range_backward(
+            effective_start=450, target_block=1000, last_backward_block=501, chunk_size=200
+        )
+        assert result == (450, 500)
+
+    def test_done_when_already_at_effective_start(self):
+        result = _resolve_scan_range_backward(
+            effective_start=100, target_block=1000, last_backward_block=100, chunk_size=500
+        )
+        assert result is None
+
+    def test_done_when_below_effective_start(self):
+        result = _resolve_scan_range_backward(
+            effective_start=100, target_block=1000, last_backward_block=50, chunk_size=500
+        )
+        assert result is None
+
+    def test_target_below_effective_start_returns_none(self):
+        result = _resolve_scan_range_backward(
+            effective_start=500, target_block=200, last_backward_block=None, chunk_size=100
+        )
+        assert result is None
+
+    def test_single_block_range(self):
+        result = _resolve_scan_range_backward(
+            effective_start=5, target_block=5, last_backward_block=None, chunk_size=100
+        )
+        assert result == (5, 5)
+
+
+# ---------------------------------------------------------------------------
+# _get_backward_progress / _upsert_backward_progress — DB helpers
+# ---------------------------------------------------------------------------
+
+class TestBackwardProgressPersistence:
+    def test_returns_none_when_no_record(self):
+        with Session(_ENGINE) as session:
+            result = _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
+        assert result is None
+
+    def test_upsert_creates_and_retrieves(self):
+        with Session(_ENGINE) as session:
+            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 12345)
+            session.commit()
+            result = _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
+        assert result == 12345
+
+    def test_upsert_updates_existing(self):
+        with Session(_ENGINE) as session:
+            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 12345)
+            session.commit()
+            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 9000)
+            session.commit()
+            result = _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct")
+        assert result == 9000
+
+    def test_different_types_are_independent(self):
+        with Session(_ENGINE) as session:
+            _upsert_backward_progress(session, "0xaaa", "0xbbb", "contract_direct", 100)
+            _upsert_backward_progress(session, "0xaaa", "0xbbb", "sender_direct", 200)
+            session.commit()
+            assert _get_backward_progress(session, "0xaaa", "0xbbb", "contract_direct") == 100
+            assert _get_backward_progress(session, "0xaaa", "0xbbb", "sender_direct") == 200
+
+
+# ---------------------------------------------------------------------------
+# _fill_skipped_ranges_for_row
+# ---------------------------------------------------------------------------
+
+def _make_scan_state(session: Session, from_addr: str, to_addr: str, itype: str) -> InteractionScanState:
+    row = InteractionScanState(
+        from_address=from_addr,
+        to_address=to_addr,
+        interaction_type=itype,
+        from_block=0,
+        last_analyzed_block=None,
+        how_many_times=0,
+        first_time_interact=True,
+        needs_creation_retry=False,
+    )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
+def _make_hole(
+    session: Session, from_addr: str, to_addr: str, itype: str, start: int, end: int
+) -> InteractionScanSkippedRange:
+    hole = InteractionScanSkippedRange(
+        from_address=from_addr,
+        to_address=to_addr,
+        interaction_type=itype,
+        range_start=start,
+        range_end=end,
+        reason="scan_error",
+    )
+    session.add(hole)
+    session.commit()
+    return hole
+
+
+class TestFillSkippedRanges:
+    def test_no_holes_returns_zero(self):
+        with Session(_ENGINE) as session:
+            row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
+            mock_w3 = MagicMock()
+            hits, filled = _fill_skipped_ranges_for_row(
+                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            )
+        assert hits == 0
+        assert filled == 0
+
+    def test_successful_retry_removes_hole_and_counts_hits(self, monkeypatch):
+        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+            return 3, []  # 3 hits, no skipped ranges
+
+        monkeypatch.setattr(
+            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
+        )
+        with Session(_ENGINE) as session:
+            row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
+            _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
+
+            mock_w3 = MagicMock()
+            hits, filled = _fill_skipped_ranges_for_row(
+                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            )
+
+            remaining = session.exec(
+                select(InteractionScanSkippedRange).where(
+                    InteractionScanSkippedRange.from_address == "0xaaa"
+                )
+            ).all()
+
+        assert hits == 3
+        assert filled == 1
+        assert len(remaining) == 0
+
+    def test_still_failing_hole_stays_recorded(self, monkeypatch):
+        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+            return 0, [(scan_start, scan_end)]  # still fails
+
+        monkeypatch.setattr(
+            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
+        )
+        with Session(_ENGINE) as session:
+            row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
+            _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
+
+            mock_w3 = MagicMock()
+            hits, filled = _fill_skipped_ranges_for_row(
+                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            )
+
+            remaining = session.exec(
+                select(InteractionScanSkippedRange).where(
+                    InteractionScanSkippedRange.from_address == "0xaaa"
+                )
+            ).all()
+
+        assert hits == 0
+        assert filled == 0
+        assert len(remaining) == 1
+
+    def test_dry_run_does_not_delete_hole(self, monkeypatch):
+        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+            return 5, []
+
+        monkeypatch.setattr(
+            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
+        )
+        with Session(_ENGINE) as session:
+            row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
+            _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
+
+            mock_w3 = MagicMock()
+            hits, filled = _fill_skipped_ranges_for_row(
+                session, mock_w3, row, 50, "contract_direct", dry_run=True
+            )
+
+            remaining = session.exec(
+                select(InteractionScanSkippedRange).where(
+                    InteractionScanSkippedRange.from_address == "0xaaa"
+                )
+            ).all()
+
+        assert hits == 5
+        assert filled == 1
+        assert len(remaining) == 1  # hole preserved in dry-run
+
+    def test_successful_retry_updates_how_many_times(self, monkeypatch):
+        def fake_scan_chunk(w3, from_addr, to_addr, scan_start, scan_end, page_size, ntype):
+            return 7, []
+
+        monkeypatch.setattr(
+            "backfill_first_time_interactions_core._scan_chunk", fake_scan_chunk
+        )
+        with Session(_ENGINE) as session:
+            row = _make_scan_state(session, "0xaaa", "0xbbb", "contract_direct")
+            row.how_many_times = 2
+            session.add(row)
+            session.commit()
+            _make_hole(session, "0xaaa", "0xbbb", "contract_direct", 1000, 2000)
+
+            mock_w3 = MagicMock()
+            _fill_skipped_ranges_for_row(
+                session, mock_w3, row, 50, "contract_direct", dry_run=False
+            )
+            session.refresh(row)
+
+        assert row.how_many_times == 9  # 2 existing + 7 from hole

--- a/webapp/backend/tools/backfill_backward_helpers.py
+++ b/webapp/backend/tools/backfill_backward_helpers.py
@@ -1,0 +1,130 @@
+"""Pure helpers for backward scan and hole-filling — no app config dependency."""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from sqlmodel import Session, select
+
+ROOT = Path(__file__).resolve().parents[1]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from src.api.models.interaction_scan_backward_progress import InteractionScanBackwardProgress
+from src.api.models.interaction_scan_skipped_range import InteractionScanSkippedRange
+from src.api.models.interaction_scan_state import InteractionScanState
+
+
+def resolve_scan_range_backward(
+    effective_start: int,
+    target_block: int,
+    last_backward_block: Optional[int],
+    chunk_size: int,
+) -> Optional[tuple[int, int]]:
+    """Return next (scan_start, scan_end) for the backward pass, or None when done."""
+    if last_backward_block is not None and last_backward_block <= effective_start:
+        return None
+    scan_end = (last_backward_block - 1) if last_backward_block is not None else target_block
+    if scan_end < effective_start:
+        return None
+    scan_start = max(effective_start, scan_end - chunk_size + 1)
+    return scan_start, scan_end
+
+
+def get_backward_progress(
+    session: Session,
+    from_address: str,
+    to_address: str,
+    interaction_type: str,
+) -> Optional[int]:
+    """Return last_backward_block for the pair, or None if not started."""
+    rec = session.exec(
+        select(InteractionScanBackwardProgress).where(
+            InteractionScanBackwardProgress.from_address == from_address,
+            InteractionScanBackwardProgress.to_address == to_address,
+            InteractionScanBackwardProgress.interaction_type == interaction_type,
+        )
+    ).first()
+    return rec.last_backward_block if rec else None
+
+
+def upsert_backward_progress(
+    session: Session,
+    from_address: str,
+    to_address: str,
+    interaction_type: str,
+    last_backward_block: int,
+) -> None:
+    rec = session.exec(
+        select(InteractionScanBackwardProgress).where(
+            InteractionScanBackwardProgress.from_address == from_address,
+            InteractionScanBackwardProgress.to_address == to_address,
+            InteractionScanBackwardProgress.interaction_type == interaction_type,
+        )
+    ).first()
+    if rec is None:
+        rec = InteractionScanBackwardProgress(
+            from_address=from_address,
+            to_address=to_address,
+            interaction_type=interaction_type,
+            last_backward_block=last_backward_block,
+            updated_at=datetime.utcnow(),
+        )
+    else:
+        rec.last_backward_block = last_backward_block
+        rec.updated_at = datetime.utcnow()
+    session.add(rec)
+
+
+def fill_skipped_ranges_for_row(
+    session: Session,
+    scan_chunk_fn,
+    w3,
+    row: InteractionScanState,
+    page_size: int,
+    normalized_type: str,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Retry recorded skipped ranges for a row. Returns (total_hits, ranges_filled)."""
+    holes = session.exec(
+        select(InteractionScanSkippedRange).where(
+            InteractionScanSkippedRange.from_address == row.from_address,
+            InteractionScanSkippedRange.to_address == row.to_address,
+            InteractionScanSkippedRange.interaction_type == normalized_type,
+        )
+    ).all()
+    if not holes:
+        return 0, 0
+    total_hits = 0
+    filled = 0
+    for hole in holes:
+        hits, still_skipped = scan_chunk_fn(
+            w3,
+            row.from_address,
+            row.to_address,
+            hole.range_start,
+            hole.range_end,
+            page_size,
+            normalized_type,
+        )
+        if not still_skipped:
+            total_hits += hits
+            filled += 1
+            print(
+                f"[fill-hole] id={row.id} type={normalized_type} "
+                f"{row.from_address}->{row.to_address} "
+                f"range={hole.range_start}-{hole.range_end} hits={hits}"
+            )
+            if not dry_run:
+                session.delete(hole)
+    if not dry_run and filled > 0:
+        new_total = max(0, int(row.how_many_times)) + total_hits
+        row.how_many_times = new_total
+        row.first_time_interact = new_total == 0
+        row.checked_at = datetime.utcnow()
+        session.add(row)
+        session.commit()
+    return total_hits, filled

--- a/webapp/backend/tools/backfill_first_time_interactions_core.py
+++ b/webapp/backend/tools/backfill_first_time_interactions_core.py
@@ -74,6 +74,7 @@ from src.api.models.interaction_scan_hot import InteractionScanHot
 from src.api.models.interaction_scan_skipped_range import InteractionScanSkippedRange
 from src.api.models.interaction_scan_state import InteractionScanState
 import backfill_interaction_checks as interaction_checks
+import backfill_backward_helpers as _bwd
 
 
 def _normalize_address(address: str | None) -> Optional[str]:
@@ -106,49 +107,12 @@ def _ensure_state_table() -> None:
     )
 
 
-def _get_backward_progress(
-    session: Session,
-    from_address: str,
-    to_address: str,
-    interaction_type: str,
-) -> Optional[int]:
-    """Return last_backward_block for the pair, or None if not started."""
-    rec = session.exec(
-        select(InteractionScanBackwardProgress).where(
-            InteractionScanBackwardProgress.from_address == from_address,
-            InteractionScanBackwardProgress.to_address == to_address,
-            InteractionScanBackwardProgress.interaction_type == interaction_type,
-        )
-    ).first()
-    return rec.last_backward_block if rec else None
+def _get_backward_progress(session, from_address, to_address, interaction_type):
+    return _bwd.get_backward_progress(session, from_address, to_address, interaction_type)
 
 
-def _upsert_backward_progress(
-    session: Session,
-    from_address: str,
-    to_address: str,
-    interaction_type: str,
-    last_backward_block: int,
-) -> None:
-    rec = session.exec(
-        select(InteractionScanBackwardProgress).where(
-            InteractionScanBackwardProgress.from_address == from_address,
-            InteractionScanBackwardProgress.to_address == to_address,
-            InteractionScanBackwardProgress.interaction_type == interaction_type,
-        )
-    ).first()
-    if rec is None:
-        rec = InteractionScanBackwardProgress(
-            from_address=from_address,
-            to_address=to_address,
-            interaction_type=interaction_type,
-            last_backward_block=last_backward_block,
-            updated_at=datetime.utcnow(),
-        )
-    else:
-        rec.last_backward_block = last_backward_block
-        rec.updated_at = datetime.utcnow()
-    session.add(rec)
+def _upsert_backward_progress(session, from_address, to_address, interaction_type, last_backward_block):
+    _bwd.upsert_backward_progress(session, from_address, to_address, interaction_type, last_backward_block)
 
 
 def _seed_scan_rows_from_first_time(
@@ -744,37 +708,15 @@ def _is_first_time_interact(total_interactions: int) -> bool:
     return int(total_interactions) == 0
 
 
-def _resolve_scan_range_backward(
-    effective_start: int,
-    target_block: int,
-    last_backward_block: Optional[int],
-    chunk_size: int,
-) -> Optional[tuple[int, int]]:
-    """Return next (scan_start, scan_end) for the backward pass, or None when done."""
-    if last_backward_block is not None and last_backward_block <= effective_start:
-        return None
-    scan_end = (last_backward_block - 1) if last_backward_block is not None else target_block
-    if scan_end < effective_start:
-        return None
-    scan_start = max(effective_start, scan_end - chunk_size + 1)
-    return scan_start, scan_end
+def _resolve_scan_range_backward(effective_start, target_block, last_backward_block, chunk_size):
+    return _bwd.resolve_scan_range_backward(effective_start, target_block, last_backward_block, chunk_size)
 
 
-def _scan_chunk(
-    w3,
-    from_address: str,
-    to_address: str,
-    scan_start: int,
-    scan_end: int,
-    page_size: int,
-    normalized_type: str,
-) -> tuple[int, list[tuple[int, int]]]:
+def _scan_chunk(w3, from_address, to_address, scan_start, scan_end, page_size, normalized_type):
     """Dispatch one block-range scan for the given interaction type."""
     _sync_interaction_check_settings()
     if normalized_type in TRANSITIVE_INTERACTION_TYPES:
-        return _count_transitive_interactions(
-            w3, from_address, to_address, scan_start, scan_end, page_size
-        )
+        return _count_transitive_interactions(w3, from_address, to_address, scan_start, scan_end, page_size)
     if normalized_type == "sender_direct":
         return _count_direct_interactions(
             w3, from_address, to_address, scan_start, scan_end, page_size,
@@ -786,54 +728,8 @@ def _scan_chunk(
     )
 
 
-def _fill_skipped_ranges_for_row(
-    session: Session,
-    w3,
-    row: "InteractionScanState",
-    page_size: int,
-    normalized_type: str,
-    dry_run: bool,
-) -> tuple[int, int]:
-    """Retry recorded skipped ranges for a row. Returns (total_hits, ranges_filled)."""
-    holes = session.exec(
-        select(InteractionScanSkippedRange).where(
-            InteractionScanSkippedRange.from_address == row.from_address,
-            InteractionScanSkippedRange.to_address == row.to_address,
-            InteractionScanSkippedRange.interaction_type == normalized_type,
-        )
-    ).all()
-    if not holes:
-        return 0, 0
-    total_hits = 0
-    filled = 0
-    for hole in holes:
-        hits, still_skipped = _scan_chunk(
-            w3,
-            row.from_address,
-            row.to_address,
-            hole.range_start,
-            hole.range_end,
-            page_size,
-            normalized_type,
-        )
-        if not still_skipped:
-            total_hits += hits
-            filled += 1
-            print(
-                f"[fill-hole] id={row.id} type={normalized_type} "
-                f"{row.from_address}->{row.to_address} "
-                f"range={hole.range_start}-{hole.range_end} hits={hits}"
-            )
-            if not dry_run:
-                session.delete(hole)
-    if not dry_run and filled > 0:
-        new_total = max(0, int(row.how_many_times)) + total_hits
-        row.how_many_times = new_total
-        row.first_time_interact = _is_first_time_interact(new_total)
-        row.checked_at = datetime.utcnow()
-        session.add(row)
-        session.commit()
-    return total_hits, filled
+def _fill_skipped_ranges_for_row(session, w3, row, page_size, normalized_type, dry_run):
+    return _bwd.fill_skipped_ranges_for_row(session, _scan_chunk, w3, row, page_size, normalized_type, dry_run)
 
 
 def _get_hot_record(

--- a/webapp/backend/tools/backfill_first_time_interactions_core.py
+++ b/webapp/backend/tools/backfill_first_time_interactions_core.py
@@ -69,6 +69,7 @@ from src.api.crud import deployment as deployment_crud
 from src.api.models.address_metadata import AddressMetadata
 from src.api.models.deployment import Deployment, DeploymentCreate
 from src.api.models.first_interaction import FirstInteraction
+from src.api.models.interaction_scan_backward_progress import InteractionScanBackwardProgress
 from src.api.models.interaction_scan_hot import InteractionScanHot
 from src.api.models.interaction_scan_skipped_range import InteractionScanSkippedRange
 from src.api.models.interaction_scan_state import InteractionScanState
@@ -100,8 +101,54 @@ def _ensure_state_table() -> None:
             AddressMetadata.__table__,
             InteractionScanHot.__table__,
             InteractionScanSkippedRange.__table__,
+            InteractionScanBackwardProgress.__table__,
         ],
     )
+
+
+def _get_backward_progress(
+    session: Session,
+    from_address: str,
+    to_address: str,
+    interaction_type: str,
+) -> Optional[int]:
+    """Return last_backward_block for the pair, or None if not started."""
+    rec = session.exec(
+        select(InteractionScanBackwardProgress).where(
+            InteractionScanBackwardProgress.from_address == from_address,
+            InteractionScanBackwardProgress.to_address == to_address,
+            InteractionScanBackwardProgress.interaction_type == interaction_type,
+        )
+    ).first()
+    return rec.last_backward_block if rec else None
+
+
+def _upsert_backward_progress(
+    session: Session,
+    from_address: str,
+    to_address: str,
+    interaction_type: str,
+    last_backward_block: int,
+) -> None:
+    rec = session.exec(
+        select(InteractionScanBackwardProgress).where(
+            InteractionScanBackwardProgress.from_address == from_address,
+            InteractionScanBackwardProgress.to_address == to_address,
+            InteractionScanBackwardProgress.interaction_type == interaction_type,
+        )
+    ).first()
+    if rec is None:
+        rec = InteractionScanBackwardProgress(
+            from_address=from_address,
+            to_address=to_address,
+            interaction_type=interaction_type,
+            last_backward_block=last_backward_block,
+            updated_at=datetime.utcnow(),
+        )
+    else:
+        rec.last_backward_block = last_backward_block
+        rec.updated_at = datetime.utcnow()
+    session.add(rec)
 
 
 def _seed_scan_rows_from_first_time(
@@ -697,6 +744,98 @@ def _is_first_time_interact(total_interactions: int) -> bool:
     return int(total_interactions) == 0
 
 
+def _resolve_scan_range_backward(
+    effective_start: int,
+    target_block: int,
+    last_backward_block: Optional[int],
+    chunk_size: int,
+) -> Optional[tuple[int, int]]:
+    """Return next (scan_start, scan_end) for the backward pass, or None when done."""
+    if last_backward_block is not None and last_backward_block <= effective_start:
+        return None
+    scan_end = (last_backward_block - 1) if last_backward_block is not None else target_block
+    if scan_end < effective_start:
+        return None
+    scan_start = max(effective_start, scan_end - chunk_size + 1)
+    return scan_start, scan_end
+
+
+def _scan_chunk(
+    w3,
+    from_address: str,
+    to_address: str,
+    scan_start: int,
+    scan_end: int,
+    page_size: int,
+    normalized_type: str,
+) -> tuple[int, list[tuple[int, int]]]:
+    """Dispatch one block-range scan for the given interaction type."""
+    _sync_interaction_check_settings()
+    if normalized_type in TRANSITIVE_INTERACTION_TYPES:
+        return _count_transitive_interactions(
+            w3, from_address, to_address, scan_start, scan_end, page_size
+        )
+    if normalized_type == "sender_direct":
+        return _count_direct_interactions(
+            w3, from_address, to_address, scan_start, scan_end, page_size,
+            root_only=True, mode_name="sender_direct",
+        )
+    return _count_direct_interactions(
+        w3, from_address, to_address, scan_start, scan_end, page_size,
+        root_only=False, mode_name="contract_direct",
+    )
+
+
+def _fill_skipped_ranges_for_row(
+    session: Session,
+    w3,
+    row: "InteractionScanState",
+    page_size: int,
+    normalized_type: str,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Retry recorded skipped ranges for a row. Returns (total_hits, ranges_filled)."""
+    holes = session.exec(
+        select(InteractionScanSkippedRange).where(
+            InteractionScanSkippedRange.from_address == row.from_address,
+            InteractionScanSkippedRange.to_address == row.to_address,
+            InteractionScanSkippedRange.interaction_type == normalized_type,
+        )
+    ).all()
+    if not holes:
+        return 0, 0
+    total_hits = 0
+    filled = 0
+    for hole in holes:
+        hits, still_skipped = _scan_chunk(
+            w3,
+            row.from_address,
+            row.to_address,
+            hole.range_start,
+            hole.range_end,
+            page_size,
+            normalized_type,
+        )
+        if not still_skipped:
+            total_hits += hits
+            filled += 1
+            print(
+                f"[fill-hole] id={row.id} type={normalized_type} "
+                f"{row.from_address}->{row.to_address} "
+                f"range={hole.range_start}-{hole.range_end} hits={hits}"
+            )
+            if not dry_run:
+                session.delete(hole)
+    if not dry_run and filled > 0:
+        new_total = max(0, int(row.how_many_times)) + total_hits
+        row.how_many_times = new_total
+        row.first_time_interact = _is_first_time_interact(new_total)
+        row.checked_at = datetime.utcnow()
+        session.add(row)
+        session.commit()
+    return total_hits, filled
+
+
 def _get_hot_record(
     session: Session,
     from_address: str,
@@ -982,6 +1121,19 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Process one chunk per row per round until target block is reached",
     )
+    parser.add_argument(
+        "--scan-backwards",
+        action="store_true",
+        help=(
+            "Scan from the latest block backwards toward the creation block. "
+            "Progress is tracked in interaction_scan_backward_progress."
+        ),
+    )
+    parser.add_argument(
+        "--fill-holes",
+        action="store_true",
+        help="After scanning each row, retry any ranges recorded in interaction_scan_skipped_range.",
+    )
     return parser.parse_args()
 
 
@@ -1100,11 +1252,13 @@ def main() -> None:
                 break
 
             for row in processing_rows:
-                if row.last_analyzed_block is not None and int(
-                    row.last_analyzed_block
-                ) >= int(target_block):
-                    round_skipped_done += 1
-                    continue
+                # Forward-mode done check: already reached target block.
+                if not args.scan_backwards:
+                    if row.last_analyzed_block is not None and int(
+                        row.last_analyzed_block
+                    ) >= int(target_block):
+                        round_skipped_done += 1
+                        continue
                 round_remaining += 1
                 processed += 1
 
@@ -1194,6 +1348,19 @@ def main() -> None:
                 if row.last_analyzed_block is None:
                     row.from_block = effective_start
 
+                # Backward-mode: load persisted progress from the separate table.
+                if args.scan_backwards:
+                    last_backward_block = _get_backward_progress(
+                        session,
+                        row.from_address,
+                        row.to_address,
+                        normalized_type,
+                    )
+                    before_last_backward = last_backward_block
+                else:
+                    last_backward_block = None
+                    before_last_backward = None
+
                 row_started = time.perf_counter()
                 while chunks_done < max_chunks_per_row:
                     row_runtime_sec = time.perf_counter() - row_started
@@ -1218,62 +1385,60 @@ def main() -> None:
                         if not args.dry_run:
                             session.commit()
                         break
-                    scan_start = _resolve_scan_start(
-                        row.from_block,
-                        from_lower_bound,
-                        row.last_analyzed_block,
-                        args.override_start,
-                    )
-                    if scan_start < row.from_block:
-                        print(
-                            f"[warn] scan_start below creation id={row.id} "
-                            f"scan_start={scan_start} from_block={row.from_block}"
-                        )
-                        scan_start = row.from_block
 
-                    if scan_start > target_block:
-                        round_remaining -= 1
-                        round_skipped_done += 1
-                        print(
-                            f"[skip] scan start beyond target id={row.id} type={normalized_type} "
-                            f"scan_start={scan_start} target={target_block}"
+                    if args.scan_backwards:
+                        bwd = _resolve_scan_range_backward(
+                            effective_start,
+                            target_block,
+                            last_backward_block,
+                            chunk_size,
                         )
-                        break
+                        if bwd is None:
+                            round_remaining -= 1
+                            round_skipped_done += 1
+                            print(
+                                f"[skip] backward scan complete id={row.id} "
+                                f"type={normalized_type} "
+                                f"{row.from_address}->{row.to_address}"
+                            )
+                            break
+                        scan_start, scan_end = bwd
+                    else:
+                        scan_start = _resolve_scan_start(
+                            row.from_block,
+                            from_lower_bound,
+                            row.last_analyzed_block,
+                            args.override_start,
+                        )
+                        if scan_start < row.from_block:
+                            print(
+                                f"[warn] scan_start below creation id={row.id} "
+                                f"scan_start={scan_start} from_block={row.from_block}"
+                            )
+                            scan_start = row.from_block
 
-                    scan_end = min(target_block, scan_start + chunk_size - 1)
+                        if scan_start > target_block:
+                            round_remaining -= 1
+                            round_skipped_done += 1
+                            print(
+                                f"[skip] scan start beyond target id={row.id} type={normalized_type} "
+                                f"scan_start={scan_start} target={target_block}"
+                            )
+                            break
+
+                        scan_end = min(target_block, scan_start + chunk_size - 1)
+
                     chunk_started = time.perf_counter()
 
-                    if normalized_type in TRANSITIVE_INTERACTION_TYPES:
-                        hits, chunk_skipped = _count_transitive_interactions(
-                            trace_collector.w3,
-                            row.from_address,
-                            row.to_address,
-                            scan_start,
-                            scan_end,
-                            page_size,
-                        )
-                    elif normalized_type == "sender_direct":
-                        hits, chunk_skipped = _count_direct_interactions(
-                            trace_collector.w3,
-                            row.from_address,
-                            row.to_address,
-                            scan_start,
-                            scan_end,
-                            page_size,
-                            root_only=True,
-                            mode_name="sender_direct",
-                        )
-                    else:
-                        hits, chunk_skipped = _count_direct_interactions(
-                            trace_collector.w3,
-                            row.from_address,
-                            row.to_address,
-                            scan_start,
-                            scan_end,
-                            page_size,
-                            root_only=False,
-                            mode_name="contract_direct",
-                        )
+                    hits, chunk_skipped = _scan_chunk(
+                        trace_collector.w3,
+                        row.from_address,
+                        row.to_address,
+                        scan_start,
+                        scan_end,
+                        page_size,
+                        normalized_type,
+                    )
 
                     if chunk_skipped and not args.dry_run:
                         for range_start, range_end in chunk_skipped:
@@ -1339,8 +1504,20 @@ def main() -> None:
                     row.first_time_interact = _is_first_time_interact(
                         new_total
                     )
-                    row.last_analyzed_block = scan_end
                     row.checked_at = datetime.utcnow()
+
+                    if args.scan_backwards:
+                        last_backward_block = scan_start
+                        if not args.dry_run:
+                            _upsert_backward_progress(
+                                session,
+                                row.from_address,
+                                row.to_address,
+                                normalized_type,
+                                scan_start,
+                            )
+                    else:
+                        row.last_analyzed_block = scan_end
 
                     if not args.dry_run:
                         session.add(row)
@@ -1349,11 +1526,31 @@ def main() -> None:
 
                     chunks_done += 1
 
-                if row.last_analyzed_block is not None and (
-                    before_last_analyzed is None
-                    or int(row.last_analyzed_block) > int(before_last_analyzed)
-                ):
-                    round_advanced += 1
+                if args.fill_holes:
+                    fill_hits, fill_count = _fill_skipped_ranges_for_row(
+                        session,
+                        trace_collector.w3,
+                        row,
+                        page_size,
+                        normalized_type,
+                        args.dry_run,
+                    )
+                    total_hits += fill_hits
+                    if fill_count > 0:
+                        updated += 1
+
+                if args.scan_backwards:
+                    if last_backward_block is not None and (
+                        before_last_backward is None
+                        or int(last_backward_block) < int(before_last_backward)
+                    ):
+                        round_advanced += 1
+                else:
+                    if row.last_analyzed_block is not None and (
+                        before_last_analyzed is None
+                        or int(row.last_analyzed_block) > int(before_last_analyzed)
+                    ):
+                        round_advanced += 1
 
             print(
                 f"[round-summary] round={rounds} target={target_block} "


### PR DESCRIPTION
## Summary

- Add `--scan-backwards`: scans from latest block backward toward the contract/EOA creation block. Progress is persisted in a new `interaction_scan_backward_progress` table (pure `CREATE TABLE` — no `ALTER TABLE` on existing tables).
- Add `--fill-holes`: after each row's chunk scan, retries any ranges recorded in `interaction_scan_skipped_range` and removes them on success.
- Extract `_scan_chunk` to deduplicate the interaction-type dispatch that was repeated inline.
- 17 new unit tests covering backward range resolution, progress persistence, and hole-filling (success / still-failing / dry-run / hit accumulation).