### PR TITLE
Use HTTP pair history for transaction risk

### DIFF
--- a/webapp/backend/.env.example
+++ b/webapp/backend/.env.example
@@ -1,6 +1,11 @@
 # Ethereum Node Configuration
 ETH_NODE_URLS=http://localhost:8545|https://api-ethereum-mainnet.n.dwellir.com/YOUR_API_KEY
 
+# Directed interaction history service
+PAIR_SEEN_SERVICE_URL=http://130.237.222.185:8091
+# PAIR_SEEN_TIMEOUT_SECONDS=10
+# PAIR_SEEN_BATCH_SIZE=1000
+
 # Database Configuration
 DATABASE_URL=postgresql://cc-user:cc-password@db:5432/cc
 

--- a/webapp/backend/src/api/core/config.py
+++ b/webapp/backend/src/api/core/config.py
@@ -72,6 +72,20 @@ class Settings(BaseSettings):
     neo4j_password: str | None = Field(default=None, alias="NEO4J_PASSWORD")
     neo4j_database: str | None = Field(default=None, alias="NEO4J_DATABASE")
 
+    # Pre-indexed directed interaction history service
+    pair_seen_service_url: str = Field(
+        ...,
+        alias="PAIR_SEEN_SERVICE_URL",
+    )
+    pair_seen_timeout_seconds: float = Field(
+        10.0,
+        alias="PAIR_SEEN_TIMEOUT_SECONDS",
+    )
+    pair_seen_batch_size: int = Field(
+        1000,
+        alias="PAIR_SEEN_BATCH_SIZE",
+    )
+
     # Request logging
     request_log_dir: str = Field(
         "./request_logs", alias="REQUEST_LOG_DIR"

--- a/webapp/backend/src/api/integrations/crystal_clear_adapter.py
+++ b/webapp/backend/src/api/integrations/crystal_clear_adapter.py
@@ -92,6 +92,51 @@ class CrystalClearRiskEngine(RiskEngine):
             finally:
                 self._client.first_time_cache = original_cache
 
+    def simulate_and_check_with_edges(
+        self,
+        call_object: Mapping[str, Any],
+        block_tag: str | int = "latest",
+        from_block: str | int | None = None,
+        to_block: str | int | None = None,
+        latest_offset: int | None = None,
+        check_first_time: bool = True,
+    ) -> tuple[dict[str, Any], list[tuple[str, str]]]:
+        collector = self._client.simulation_collector
+        if collector is None:
+            raise ValueError("SimulationCollector is not initialized.")
+
+        captured_edges: list[tuple[str, str]] = []
+        original_get_edges = collector.get_edges_from_simulation
+
+        def capture_edges(*args, **kwargs):
+            edges = original_get_edges(*args, **kwargs)
+            captured_edges.extend((edge.source, edge.target) for edge in edges)
+            return edges
+
+        with self._simulate_lock:
+            original_cache = getattr(self._client, "first_time_cache", None)
+            collector.get_edges_from_simulation = capture_edges
+            if not check_first_time:
+                self._client.first_time_cache = _NoFirstTimeCache()
+            try:
+                results = self._client.simulate_and_check(
+                    dict(call_object),
+                    block_tag=block_tag,
+                    from_block=from_block,
+                    to_block=to_block,
+                    latest_offset=latest_offset,
+                )
+            finally:
+                collector.get_edges_from_simulation = original_get_edges
+                self._client.first_time_cache = original_cache
+        return results, captured_edges
+
+    def get_latest_block_number(self) -> int:
+        collector = self._client.simulation_collector
+        if collector is None:
+            raise ValueError("SimulationCollector is not initialized.")
+        return int(collector.w3.eth.block_number)
+
     def simulate_from_tx(
         self,
         tx_hash: str,

--- a/webapp/backend/src/api/integrations/risk_engine.py
+++ b/webapp/backend/src/api/integrations/risk_engine.py
@@ -27,6 +27,20 @@ class RiskEngine(Protocol):
     ) -> dict[str, Any]:
         """Simulate calldata and return touched-contract results."""
 
+    def simulate_and_check_with_edges(
+        self,
+        call_object: Mapping[str, Any],
+        block_tag: str | int = "latest",
+        from_block: str | int | None = None,
+        to_block: str | int | None = None,
+        latest_offset: int | None = None,
+        check_first_time: bool = True,
+    ) -> tuple[dict[str, Any], list[tuple[str, str]]]:
+        """Simulate once and return both contract results and directed edges."""
+
+    def get_latest_block_number(self) -> int:
+        """Return the latest block number visible to the simulation node."""
+
     def simulate_from_tx(
         self,
         tx_hash: str,

--- a/webapp/backend/src/api/routers/analysis.py
+++ b/webapp/backend/src/api/routers/analysis.py
@@ -30,6 +30,10 @@ from src.api.services.neo4j_interaction_history import (
     InteractionKey,
     get_neo4j_interaction_history,
 )
+from src.api.services.pair_seen_interaction_history import (
+    PairKey,
+    get_pair_seen_interaction_history,
+)
 from src.api.services.tx_risk_assessment import (
     _has_allowlisted_verification,
     _has_unverified_dangerous,
@@ -117,12 +121,26 @@ def _evaluate_interaction_scan_risk(
     touched_addresses: list[str],
     checked_interaction_types: list[str],
     history_to_block: int | None = None,
+    direct_pairs: set[PairKey] | None = None,
+    transitive_pairs: set[PairKey] | None = None,
 ) -> tuple[
     dict[str, dict[str, bool]],
     dict[str, dict[str, str]],
     list[str],
     list[str],
+    list[str],
+    list[str],
 ]:
+    if direct_pairs is not None and transitive_pairs is not None:
+        return _evaluate_pair_seen_risk(
+            sender_address=sender_address,
+            touched_addresses=touched_addresses,
+            checked_interaction_types=checked_interaction_types,
+            history_to_block=history_to_block,
+            direct_pairs=direct_pairs,
+            transitive_pairs=transitive_pairs,
+        )
+
     sender_norm = _normalize_address(sender_address)
     root_norm = _normalize_address(root_contract)
     normalized_targets: list[str] = []
@@ -319,6 +337,152 @@ def _evaluate_interaction_scan_risk(
                 interaction_type not in sender_dangerous_types
             ):
                 sender_dangerous_types.append(interaction_type)
+
+    return (
+        first_time_map,
+        state_map,
+        contract_dangerous_types,
+        sender_dangerous_types,
+        contract_missing_types,
+        sender_missing_types,
+    )
+
+
+def _build_transaction_interaction_candidates(
+    *,
+    sender_address: str,
+    root_contract: str | None,
+    call_edges: list[tuple[str, str]],
+) -> tuple[set[PairKey], set[PairKey]]:
+    """Build directed edges and their non-reflexive transitive closure."""
+    direct_pairs: set[PairKey] = set()
+    for source, target in call_edges:
+        source_norm = _normalize_address(source)
+        target_norm = _normalize_address(target)
+        if source_norm and target_norm and source_norm != target_norm:
+            direct_pairs.add((source_norm, target_norm))
+
+    sender_norm = _normalize_address(sender_address)
+    root_norm = _normalize_address(root_contract)
+    if sender_norm and root_norm and sender_norm != root_norm:
+        direct_pairs.add((sender_norm, root_norm))
+
+    adjacency: dict[str, set[str]] = {}
+    for source, target in direct_pairs:
+        adjacency.setdefault(source, set()).add(target)
+
+    transitive_pairs: set[PairKey] = set()
+    for source in adjacency:
+        pending = list(adjacency[source])
+        reached: set[str] = set()
+        while pending:
+            target = pending.pop()
+            if target in reached:
+                continue
+            reached.add(target)
+            pending.extend(adjacency.get(target, ()))
+        transitive_pairs.update(
+            (source, target) for target in reached if source != target
+        )
+    return direct_pairs, transitive_pairs
+
+
+def _evaluate_pair_seen_risk(
+    *,
+    sender_address: str,
+    touched_addresses: list[str],
+    checked_interaction_types: list[str],
+    history_to_block: int | None,
+    direct_pairs: set[PairKey],
+    transitive_pairs: set[PairKey],
+) -> tuple[
+    dict[str, dict[str, bool]],
+    dict[str, dict[str, str]],
+    list[str],
+    list[str],
+    list[str],
+    list[str],
+]:
+    sender_norm = _normalize_address(sender_address)
+    normalized_targets = list(
+        dict.fromkeys(
+            address
+            for address in (_normalize_address(item) for item in touched_addresses)
+            if address
+        )
+    )
+    if not sender_norm or not normalized_targets or not checked_interaction_types:
+        return {}, {}, [], [], [], []
+
+    all_candidates = direct_pairs | transitive_pairs
+    pair_history: dict[PairKey, bool] = {}
+    history_available = history_to_block is not None
+    if history_available and all_candidates:
+        try:
+            pair_history = get_pair_seen_interaction_history().has_pairs_seen(
+                all_candidates,
+                block=history_to_block,
+            )
+        except Exception as exc:
+            history_available = False
+            logger.warning("Pair-seen interaction history lookup failed: {}", exc)
+
+    first_time_map: dict[str, dict[str, bool]] = {}
+    state_map: dict[str, dict[str, str]] = {}
+    contract_dangerous_types: list[str] = []
+    sender_dangerous_types: list[str] = []
+    contract_missing_types: list[str] = []
+    sender_missing_types: list[str] = []
+
+    for target in normalized_targets:
+        first_time_map[target] = {}
+        state_map[target] = {}
+        for interaction_type in checked_interaction_types:
+            candidates = (
+                transitive_pairs
+                if interaction_type.endswith("_transitive")
+                else direct_pairs
+            )
+            if interaction_type.startswith("sender_"):
+                relevant = {(sender_norm, target)} & candidates
+            else:
+                relevant = {
+                    pair
+                    for pair in candidates
+                    if pair[1] == target and pair[0] != sender_norm
+                }
+
+            if not relevant:
+                is_first_time = False
+                state = "FOUND"
+            elif not history_available:
+                is_first_time = True
+                state = "MISSING"
+            else:
+                is_first_time = any(
+                    not pair_history[pair] for pair in relevant
+                )
+                state = "FOUND"
+
+            first_time_map[target][interaction_type] = is_first_time
+            state_map[target][interaction_type] = state
+            if not is_first_time:
+                continue
+
+            if state == "MISSING":
+                destination = (
+                    sender_missing_types
+                    if interaction_type.startswith("sender_")
+                    else contract_missing_types
+                )
+            else:
+                destination = (
+                    sender_dangerous_types
+                    if interaction_type.startswith("sender_")
+                    else contract_dangerous_types
+                )
+            if interaction_type not in destination:
+                destination.append(interaction_type)
 
     return (
         first_time_map,
@@ -1142,15 +1306,31 @@ async def get_tx_risk_from_raw(
     if tb is None:
         tb = _default_to_block_from_block_tag(body.block_tag)
 
-    # Simulation step
-    results = risk_engine.simulate_and_check(
-        call_object,
-        block_tag=body.block_tag or "latest",
-        from_block=fb,
-        to_block=tb,
-        latest_offset=body.latest_offset,
-        check_first_time=False,
+    # Simulate once and preserve the directed call edges used to build the
+    # transaction-local reachability graph.
+    simulation_kwargs = {
+        "block_tag": body.block_tag or "latest",
+        "from_block": fb,
+        "to_block": tb,
+        "latest_offset": body.latest_offset,
+        "check_first_time": False,
+    }
+    simulate_with_edges = getattr(
+        risk_engine,
+        "simulate_and_check_with_edges",
+        None,
     )
+    if callable(simulate_with_edges):
+        results, call_edges = simulate_with_edges(
+            call_object,
+            **simulation_kwargs,
+        )
+    else:
+        results = risk_engine.simulate_and_check(
+            call_object,
+            **simulation_kwargs,
+        )
+        call_edges = []
     touched_addresses = list(results.keys())
     checked_interaction_types = _resolve_checked_interaction_types(
         [body.interaction_type] if body.interaction_type else None,
@@ -1169,23 +1349,23 @@ async def get_tx_risk_from_raw(
         for addr, info in results.items()
     ]
 
-    # Seed scan-state rows from this request so backfill can process observed pairs.
-    try:
-        seeded_rows = seed_interaction_scan_state_from_tx(
-            session=session,
-            sender_address=sender,
-            root_contract=call_object.get("to"),
-            touched_addresses=touched_addresses,
+    direct_pairs, transitive_pairs = _build_transaction_interaction_candidates(
+        sender_address=sender,
+        root_contract=call_object.get("to"),
+        call_edges=call_edges,
+    )
+    history_to_block = _block_number_to_int(tb)
+    if history_to_block is None:
+        get_latest_block_number = getattr(
+            risk_engine,
+            "get_latest_block_number",
+            None,
         )
-        logger.info(
-            "tx-risk-raw seeded interaction_scan_state rows: {}",
-            seeded_rows,
-        )
-    except Exception as exc:
-        logger.warning(
-            "tx-risk-raw failed to seed interaction_scan_state: {}",
-            exc,
-        )
+        if callable(get_latest_block_number):
+            try:
+                history_to_block = int(get_latest_block_number())
+            except Exception as exc:
+                logger.warning("Failed to resolve latest history block: {}", exc)
 
     (
         interaction_first_time,
@@ -1200,7 +1380,9 @@ async def get_tx_risk_from_raw(
         root_contract=call_object.get("to"),
         touched_addresses=touched_addresses,
         checked_interaction_types=checked_interaction_types,
-        history_to_block=_block_number_to_int(tb),
+        history_to_block=history_to_block,
+        direct_pairs=direct_pairs,
+        transitive_pairs=transitive_pairs,
     )
     for item in items:
         normalized = _normalize_address(item["address"]) or ""

--- a/webapp/backend/src/api/services/pair_seen_interaction_history.py
+++ b/webapp/backend/src/api/services/pair_seen_interaction_history.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from urllib.request import Request, urlopen
+
+from src.api.core.config import settings
+
+PairKey = tuple[str, str]
+
+
+def _normalize_address(address: str | None) -> str | None:
+    if not address:
+        return None
+    value = address.strip().lower()
+    if not value.startswith("0x") or len(value) != 42:
+        return None
+    try:
+        bytes.fromhex(value[2:])
+    except ValueError:
+        return None
+    return value
+
+
+class PairSeenInteractionHistory:
+    """Batch client for the directed historical pair service."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+        batch_size: int | None = None,
+    ) -> None:
+        self._url = (
+            base_url or settings.pair_seen_service_url
+        ).rstrip("/") + "/v1/pair-seen/batch"
+        self._timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else settings.pair_seen_timeout_seconds
+        )
+        self._batch_size = max(
+            1,
+            batch_size
+            if batch_size is not None
+            else settings.pair_seen_batch_size,
+        )
+
+    def has_pairs_seen(
+        self,
+        entries: Iterable[PairKey],
+        *,
+        block: int,
+    ) -> dict[PairKey, bool]:
+        if block < 0:
+            raise ValueError("history block must be non-negative")
+
+        normalized_pairs: set[PairKey] = set()
+        for source, target in entries:
+            source_norm = _normalize_address(source)
+            target_norm = _normalize_address(target)
+            if not source_norm or not target_norm:
+                raise ValueError(f"invalid interaction pair: {source} -> {target}")
+            normalized_pairs.add((source_norm, target_norm))
+
+        ordered_pairs = sorted(normalized_pairs)
+        found: dict[PairKey, bool] = {}
+        for offset in range(0, len(ordered_pairs), self._batch_size):
+            batch = ordered_pairs[offset : offset + self._batch_size]
+            found.update(self._request_batch(batch, block=block))
+
+        missing = normalized_pairs.difference(found)
+        if missing:
+            raise RuntimeError(
+                f"pair-seen response omitted {len(missing)} requested pair(s)"
+            )
+        return found
+
+    def _request_batch(
+        self,
+        pairs: list[PairKey],
+        *,
+        block: int,
+    ) -> dict[PairKey, bool]:
+        payload = json.dumps(
+            {
+                "block": block,
+                "pairs": [
+                    {"source": source, "target": target}
+                    for source, target in pairs
+                ],
+            }
+        ).encode("utf-8")
+        request = Request(
+            self._url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urlopen(request, timeout=self._timeout_seconds) as response:
+            body = json.load(response)
+
+        results = body.get("results")
+        if not isinstance(results, list):
+            raise RuntimeError("pair-seen response has no results list")
+
+        found: dict[PairKey, bool] = {}
+        for item in results:
+            if not isinstance(item, dict):
+                raise RuntimeError("pair-seen result is not an object")
+            source = _normalize_address(item.get("source"))
+            target = _normalize_address(item.get("target"))
+            seen = item.get("seenAtOrBeforeBlock")
+            if not source or not target or not isinstance(seen, bool):
+                raise RuntimeError("pair-seen result is malformed")
+            found[(source, target)] = seen
+        return found
+
+
+_pair_seen_history: PairSeenInteractionHistory | None = None
+
+
+def get_pair_seen_interaction_history() -> PairSeenInteractionHistory:
+    global _pair_seen_history
+    if _pair_seen_history is None:
+        _pair_seen_history = PairSeenInteractionHistory()
+    return _pair_seen_history
+
+
+__all__ = [
+    "PairKey",
+    "PairSeenInteractionHistory",
+    "get_pair_seen_interaction_history",
+]

--- a/webapp/backend/tests/integrations/test_crystal_clear_adapter.py
+++ b/webapp/backend/tests/integrations/test_crystal_clear_adapter.py
@@ -1,6 +1,27 @@
 from src.api.integrations import crystal_clear_adapter as adapter
 
 
+class _Edge:
+    def __init__(self, source, target):
+        self.source = source
+        self.target = target
+
+
+class _Eth:
+    block_number = 123456
+
+
+class _Web3:
+    eth = _Eth()
+
+
+class _Collector:
+    w3 = _Web3()
+
+    def get_edges_from_simulation(self, *_args, **_kwargs):
+        return [_Edge("0xsource", "0xtarget")]
+
+
 class _Raw:
     def __init__(self, payload):
         self._payload = payload
@@ -12,6 +33,8 @@ class _Raw:
 class _FakeCrystalClear:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+        self.first_time_cache = kwargs["first_time_cache"]
+        self.simulation_collector = _Collector()
 
     def get_risk_factors(self, *args, **kwargs):
         _ = (args, kwargs)
@@ -33,6 +56,10 @@ class _FakeCrystalClear:
         )
 
     def simulate_and_check(self, call_object, **kwargs):
+        self.simulation_collector.get_edges_from_simulation(
+            call_object,
+            block_tag=kwargs.get("block_tag", "latest"),
+        )
         return {"echo": call_object, "opts": kwargs}
 
     def simulate_from_tx(self, tx_hash, **kwargs):
@@ -51,6 +78,15 @@ def test_crystal_clear_risk_engine_methods(monkeypatch):
 
     simulated = engine.simulate_and_check({"from": "0xabc"}, block_tag="latest")
     assert simulated["echo"]["from"] == "0xabc"
+
+    simulated, edges = engine.simulate_and_check_with_edges(
+        {"from": "0xabc"},
+        block_tag="latest",
+        check_first_time=False,
+    )
+    assert simulated["echo"]["from"] == "0xabc"
+    assert edges == [("0xsource", "0xtarget")]
+    assert engine.get_latest_block_number() == 123456
 
     by_tx = engine.simulate_from_tx("0xdeadbeef")
     assert by_tx["tx_hash"] == "0xdeadbeef"

--- a/webapp/backend/tests/routers/test_analysis_interaction_helpers_extra.py
+++ b/webapp/backend/tests/routers/test_analysis_interaction_helpers_extra.py
@@ -43,6 +43,120 @@ def test_normalize_address_and_resolve_checked_types():
     assert resolved == ["sender_direct"]
 
 
+def test_build_transaction_candidates_computes_directed_closure():
+    sender = "0x" + "1" * 40
+    root = "0x" + "2" * 40
+    middle = "0x" + "3" * 40
+    target = "0x" + "4" * 40
+
+    direct, transitive = analysis._build_transaction_interaction_candidates(
+        sender_address=sender,
+        root_contract=root,
+        call_edges=[
+            (root, middle),
+            (middle, target),
+            (target, root),
+            (root, root),
+        ],
+    )
+
+    assert direct == {
+        (sender, root),
+        (root, middle),
+        (middle, target),
+        (target, root),
+    }
+    assert (sender, target) in transitive
+    assert (root, target) in transitive
+    assert (target, middle) in transitive
+    assert (target, sender) not in transitive
+    assert all(source != destination for source, destination in transitive)
+
+
+def test_evaluate_pair_seen_risk_checks_exact_candidate_pairs(monkeypatch):
+    sender = "0x" + "1" * 40
+    root = "0x" + "2" * 40
+    target = "0x" + "3" * 40
+    direct = {(sender, root), (root, target)}
+    transitive = direct | {(sender, target)}
+
+    class _History:
+        def has_pairs_seen(self, entries, *, block):
+            assert set(entries) == transitive
+            assert block == 100
+            return {
+                (sender, root): True,
+                (root, target): False,
+                (sender, target): True,
+            }
+
+    monkeypatch.setattr(
+        analysis,
+        "get_pair_seen_interaction_history",
+        lambda: _History(),
+    )
+    (
+        first_map,
+        state_map,
+        contract_dangerous,
+        sender_dangerous,
+        contract_missing,
+        sender_missing,
+    ) = analysis._evaluate_pair_seen_risk(
+        sender_address=sender,
+        touched_addresses=[root, target],
+        checked_interaction_types=[
+            "sender_direct",
+            "sender_transitive",
+            "contract_direct",
+            "contract_transitive",
+        ],
+        history_to_block=100,
+        direct_pairs=direct,
+        transitive_pairs=transitive,
+    )
+
+    assert first_map[root]["sender_direct"] is False
+    assert first_map[target]["sender_direct"] is False
+    assert first_map[target]["sender_transitive"] is False
+    assert first_map[target]["contract_direct"] is True
+    assert first_map[target]["contract_transitive"] is True
+    assert state_map[target]["contract_direct"] == "FOUND"
+    assert contract_dangerous == ["contract_direct", "contract_transitive"]
+    assert sender_dangerous == []
+    assert contract_missing == []
+    assert sender_missing == []
+
+
+def test_evaluate_pair_seen_risk_marks_lookup_failure_missing(monkeypatch):
+    sender = "0x" + "1" * 40
+    root = "0x" + "2" * 40
+    target = "0x" + "3" * 40
+
+    class _History:
+        def has_pairs_seen(self, *_args, **_kwargs):
+            raise TimeoutError("history unavailable")
+
+    monkeypatch.setattr(
+        analysis,
+        "get_pair_seen_interaction_history",
+        lambda: _History(),
+    )
+    result = analysis._evaluate_pair_seen_risk(
+        sender_address=sender,
+        touched_addresses=[root, target],
+        checked_interaction_types=["contract_direct"],
+        history_to_block=100,
+        direct_pairs={(sender, root), (root, target)},
+        transitive_pairs={(sender, root), (root, target), (sender, target)},
+    )
+
+    first_map, state_map, _, _, contract_missing, _ = result
+    assert first_map[target]["contract_direct"] is True
+    assert state_map[target]["contract_direct"] == "MISSING"
+    assert contract_missing == ["contract_direct"]
+
+
 def test_resolve_checked_types_default_contract_when_not_provided():
     root = "0x1111111111111111111111111111111111111111"
     resolved = analysis._resolve_checked_interaction_types(

--- a/webapp/backend/tests/routers/test_analysis_router_tx_raw_extra.py
+++ b/webapp/backend/tests/routers/test_analysis_router_tx_raw_extra.py
@@ -496,6 +496,75 @@ async def test_tx_risk_raw_uses_numeric_block_tag_as_default_to_block(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_tx_risk_raw_builds_candidates_and_resolves_latest_block(monkeypatch):
+    sender = "0x" + "1" * 40
+    root = "0x" + "2" * 40
+    target = "0x" + "3" * 40
+    captured = {}
+
+    class _TypedObj:
+        def as_dict(self):
+            return {
+                "type": 2,
+                "to": bytes.fromhex("2" * 40),
+                "data": b"",
+                "value": 0,
+                "gas": 21000,
+            }
+
+    class _Typed:
+        @staticmethod
+        def from_bytes(_b):
+            return _TypedObj()
+
+    class _GraphEngine:
+        def simulate_and_check_with_edges(self, _call_object, **_kwargs):
+            return (
+                {
+                    root: {
+                        "verification": {"verification": "verified"},
+                        "depth": 0,
+                    },
+                    target: {
+                        "verification": {"verification": "verified"},
+                        "depth": 1,
+                    },
+                },
+                [(root, target)],
+            )
+
+        def get_latest_block_number(self):
+            return 222
+
+    def evaluate(**kwargs):
+        captured.update(kwargs)
+        return ({}, {}, [], [], [], [])
+
+    monkeypatch.setattr(analysis, "TypedTransaction", _Typed)
+    monkeypatch.setattr(
+        analysis.Account,
+        "recover_transaction",
+        lambda _b: sender,
+    )
+    monkeypatch.setattr(analysis, "_evaluate_interaction_scan_risk", evaluate)
+
+    response = await analysis.get_tx_risk_from_raw(
+        RawTxRiskRequest(raw_tx="0x02aa"),
+        risk_engine=_GraphEngine(),
+        session=object(),
+    )
+
+    assert response.status == "OK"
+    assert captured["history_to_block"] == 222
+    assert captured["direct_pairs"] == {(sender, root), (root, target)}
+    assert captured["transitive_pairs"] == {
+        (sender, root),
+        (root, target),
+        (sender, target),
+    }
+
+
+@pytest.mark.asyncio
 async def test_tx_risk_raw_keeps_explicit_to_block_over_block_tag(monkeypatch):
     _patch_interaction_helpers(monkeypatch)
 

--- a/webapp/backend/tests/services/test_pair_seen_interaction_history.py
+++ b/webapp/backend/tests/services/test_pair_seen_interaction_history.py
@@ -1,0 +1,82 @@
+import json
+
+import pytest
+
+from src.api.services import pair_seen_interaction_history as history_module
+from src.api.services.pair_seen_interaction_history import (
+    PairSeenInteractionHistory,
+)
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self):
+        return self._payload
+
+
+def test_has_pairs_seen_batches_and_normalizes(monkeypatch):
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        payload = json.loads(request.data)
+        requests.append((payload, timeout))
+        return _Response(
+            {
+                "results": [
+                    {
+                        **pair,
+                        "seenAtOrBeforeBlock": pair["source"].endswith("1"),
+                    }
+                    for pair in payload["pairs"]
+                ]
+            }
+        )
+
+    monkeypatch.setattr(history_module, "urlopen", fake_urlopen)
+    client = PairSeenInteractionHistory(
+        base_url="http://history.test",
+        timeout_seconds=3.5,
+        batch_size=1,
+    )
+    address_1 = "0x" + "0" * 39 + "1"
+    address_2 = "0x" + "0" * 39 + "2"
+    address_3 = "0x" + "0" * 39 + "3"
+
+    result = client.has_pairs_seen(
+        {
+            (address_1.upper().replace("0X", "0x"), address_2),
+            (address_2, address_3),
+        },
+        block=123,
+    )
+
+    assert result == {
+        (address_1, address_2): True,
+        (address_2, address_3): False,
+    }
+    assert len(requests) == 2
+    assert all(payload["block"] == 123 for payload, _ in requests)
+    assert all(timeout == 3.5 for _, timeout in requests)
+
+
+def test_has_pairs_seen_rejects_partial_response(monkeypatch):
+    monkeypatch.setattr(
+        history_module,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response({"results": []}),
+    )
+    client = PairSeenInteractionHistory(base_url="http://history.test")
+
+    with pytest.raises(RuntimeError, match="omitted 1 requested pair"):
+        client.has_pairs_seen(
+            {("0x" + "1" * 40, "0x" + "2" * 40)},
+            block=123,
+        )


### PR DESCRIPTION
## Summary

- preserve directed call edges from the existing transaction simulation without issuing a second `trace_call`
- compute direct pairs and the directed transitive closure of the transaction-local call graph in memory
- batch-check those exact pairs through the `/v1/pair-seen/batch` history service
- use the transaction block, an explicit history bound, or the latest block for inclusive historical checks
- make `PAIR_SEEN_SERVICE_URL` required and document the optional timeout and batch-size settings

## Why

The previous Neo4j implementation performed variable-length path traversal for each transaction risk request. Those graph queries dominated latency and could exhaust Neo4j memory. The transaction simulation already produces a small call graph, so reachability can be computed cheaply in process and historical storage only needs exact directed-pair lookups.

If the history service is unavailable or returns an incomplete batch, the endpoint reports `MISSING_HISTORY` rather than incorrectly classifying the pair as unseen.

## Impact

`POST /v1/analysis/tx-risk-raw` no longer uses Neo4j or PostgreSQL scan-state history for first-interaction checks. Deployments must set `PAIR_SEEN_SERVICE_URL`.

A single-worker replay of 2,094 deduplicated production requests completed with no timeouts, no `500` responses, and no missing-history fallbacks. Replay latency was 62.5 ms at p50, 693 ms at p95, and 2.18 s at p99 for requests that returned `200` both historically and during replay.

## Validation

- `pytest -q tests` (`300 passed`)
- live batch-service smoke test
- complete 2,094-request frozen-corpus replay
